### PR TITLE
Remove type indirection

### DIFF
--- a/src/sem/inferencer.rs
+++ b/src/sem/inferencer.rs
@@ -1,3 +1,7 @@
+//! Implements type inference.
+//!
+//! Hindley–Milner type system and Algorithm W
+//! https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system#Algorithm_W
 use crate::parser;
 use crate::parser::Expr;
 use crate::sem::{Binding, SemanticAnalyzer, Type};
@@ -32,8 +36,6 @@ impl TypeInferencer {
         }
     }
 
-    // `generic_vars` - Non
-    // `vars` - Identifier, Type
     fn analyze_function(&mut self, function: &mut parser::Function) -> Rc<RefCell<Type>> {
         // Generic type var names. Nico doesn't support generic type vars though.
         // See `freshrec()` funciton.

--- a/src/sem/mod.rs
+++ b/src/sem/mod.rs
@@ -170,33 +170,6 @@ impl fmt::Display for Type {
 }
 
 impl Type {
-    // Remmove type variable indirection.
-    pub fn fixed_type(ty: &Rc<RefCell<Type>>) -> Rc<RefCell<Type>> {
-        match &*ty.borrow() {
-            Type::Array(element_type) => wrap(Type::Array(Type::fixed_type(&element_type))),
-            Type::Function {
-                params,
-                return_type,
-            } => wrap(Type::Function {
-                params: params.iter().map(|p| Type::fixed_type(p)).collect(),
-                return_type: Type::fixed_type(return_type),
-            }),
-            Type::TypeVariable {
-                instance: Some(instance),
-                ..
-            } => Type::fixed_type(instance),
-            /*
-            Type::TypeVariable {
-                name,
-                instance: None,
-            } => {
-                panic!("Type variable `{}` must be unified", name)
-            }
-            */
-            _ => Rc::clone(ty),
-        }
-    }
-
     pub fn new_type_var(name: &str) -> Self {
         Type::TypeVariable {
             name: name.to_string(),


### PR DESCRIPTION
I implemented replacing type variables with their actual types in Inferencer instead of the Validator.