### PR TITLE
Refactor parser

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -199,6 +199,41 @@ const cases: TestCase[] = [
     ].join("\n"),
     compileError: /Missing match arm. non-exhaustive patterns/i
   },
+  {
+    // prettier-ignore
+    input: [
+      "export fun foo(a)",
+      "    case a",
+      "    when []",
+      "        10",
+      "    when [1]",
+      "        20",
+      "    when [x]",
+      "        x",
+      "    end",
+      "end"
+    ].join("\n"),
+    compileError: /Missing match arm. non-exhaustive patterns/i
+  },
+  {
+    // prettier-ignore
+    input: [
+      "export fun foo(a)",
+      "    case a",
+      "    when []",
+      "        10",
+      "    when [1]",
+      "        20",
+      "    when [x]",
+      "        x",
+      "    when x",
+      "        x[1]",
+      "    end",
+      "end"
+    ].join("\n"),
+    exec: exports => [exports.foo([]), exports.foo([1]), exports.foo([2]), exports.foo([3, 4])],
+    expected: [10, 20, 2, 4]
+  },
   // Function
   {
     file: "input/fun_55.nico",

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -199,41 +199,6 @@ const cases: TestCase[] = [
     ].join("\n"),
     compileError: /Missing match arm. non-exhaustive patterns/i
   },
-  {
-    // prettier-ignore
-    input: [
-      "export fun foo(a)",
-      "    case a",
-      "    when []",
-      "        10",
-      "    when [1]",
-      "        20",
-      "    when [x]",
-      "        x",
-      "    end",
-      "end"
-    ].join("\n"),
-    compileError: /Missing match arm. non-exhaustive patterns/i
-  },
-  {
-    // prettier-ignore
-    input: [
-      "export fun foo(a)",
-      "    case a",
-      "    when []",
-      "        10",
-      "    when [1]",
-      "        20",
-      "    when [x]",
-      "        x",
-      "    when x",
-      "        x[1]",
-      "    end",
-      "end"
-    ].join("\n"),
-    exec: exports => [exports.foo([]), exports.foo([1]), exports.foo([2]), exports.foo([3, 4])],
-    expected: [10, 20, 2, 4]
-  },
   // Function
   {
     file: "input/fun_55.nico",

--- a/src/asm/allocator.rs
+++ b/src/asm/allocator.rs
@@ -47,12 +47,8 @@ impl Allocator {
                     ref r#type,
                     ..
                 } => {
-                    let v = wrap(LocalStorage {
-                        name: naming.next(name),
-                        r#type: Rc::clone(r#type),
-                    });
-
-                    storage.replace(Rc::clone(&v));
+                    let v = LocalStorage::shared(naming.next(name), r#type);
+                    storage.replace(v);
                 }
             }
         }
@@ -69,7 +65,7 @@ impl Allocator {
         &self,
         node: &mut Node,
         naming: &mut SequenceNaming,
-        locals: &mut Vec<Rc<RefCell<LocalStorage>>>,
+        locals: &mut Vec<Rc<LocalStorage>>,
         strings: &mut Vec<Rc<RefCell<ConstantString>>>,
         frame: &mut StackFrame,
     ) {
@@ -174,10 +170,7 @@ impl Allocator {
                 // head expression.
                 self.analyze_expr(head, naming, locals, strings, frame);
                 {
-                    let temp = wrap(LocalStorage {
-                        name: naming.next("_case_head"),
-                        r#type: Rc::clone(&head.r#type),
-                    });
+                    let temp = LocalStorage::shared(naming.next("_case_head"), &head.r#type);
 
                     locals.push(Rc::clone(&temp));
                     head_storage.replace(Rc::clone(&temp));
@@ -221,7 +214,7 @@ impl Allocator {
         &self,
         pattern: &mut parser::Pattern,
         naming: &mut SequenceNaming,
-        locals: &mut Vec<Rc<RefCell<LocalStorage>>>,
+        locals: &mut Vec<Rc<LocalStorage>>,
     ) {
         // Currntly, only "Variable pattern" is supported.
         match pattern {
@@ -236,10 +229,7 @@ impl Allocator {
                         ref r#type,
                         ref mut storage,
                     } => {
-                        let v = wrap(LocalStorage {
-                            name: naming.next(name),
-                            r#type: Rc::clone(&r#type),
-                        });
+                        let v = LocalStorage::shared(naming.next(name), r#type);
 
                         locals.push(Rc::clone(&v));
                         storage.replace(Rc::clone(&v));

--- a/src/asm/allocator.rs
+++ b/src/asm/allocator.rs
@@ -41,7 +41,7 @@ impl Allocator {
         // Storage for parameters
         for ref mut binding in &function.params {
             match *binding.borrow_mut() {
-                Binding::Variable {
+                Binding {
                     ref name,
                     ref mut storage,
                     ref r#type,
@@ -54,7 +54,6 @@ impl Allocator {
 
                     storage.replace(Rc::clone(&v));
                 }
-                Binding::Function { .. } => panic!("Unexpected binding"),
             }
         }
 
@@ -232,7 +231,7 @@ impl Allocator {
                     .unwrap_or_else(|| panic!("Unbound pattern `{}`", name));
 
                 match *(binding.borrow_mut()) {
-                    Binding::Variable {
+                    Binding {
                         ref name,
                         ref r#type,
                         ref mut storage,
@@ -245,7 +244,6 @@ impl Allocator {
                         locals.push(Rc::clone(&v));
                         storage.replace(Rc::clone(&v));
                     }
-                    Binding::Function { .. } => panic!("Unexpected binding"),
                 }
             }
             parser::Pattern::Integer(_) => {}

--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -116,7 +116,7 @@ impl StackFrame {
 // local variables and function parameters.
 #[derive(Debug, PartialEq)]
 pub struct LocalStorage {
-    name: String,
+    pub name: String,
     pub r#type: Rc<RefCell<Type>>,
 }
 

--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -112,12 +112,23 @@ impl StackFrame {
     }
 }
 
-/// The struct *LocalStorage* represents name and type for
-// local variables and function parameters.
-#[derive(Debug, PartialEq)]
+/// The struct *LocalStorage* represents name and type for local variables and
+/// function parameters.
+/// This struct can be cloned because the name of storage will be unchagend
+/// after fixed.
+#[derive(Debug, PartialEq, Clone)]
 pub struct LocalStorage {
-    pub name: String,
-    pub r#type: Rc<RefCell<Type>>,
+    name: String,
+    r#type: Rc<RefCell<Type>>,
+}
+
+impl LocalStorage {
+    pub fn shared<S: AsRef<str>>(name: S, r#type: &Rc<RefCell<Type>>) -> Rc<Self> {
+        Rc::new(Self {
+            name: name.as_ref().to_string(),
+            r#type: Rc::clone(&r#type),
+        })
+    }
 }
 
 /// String literal allocation in constant pool that is allocated at compile time.

--- a/src/asm/wasm.rs
+++ b/src/asm/wasm.rs
@@ -231,13 +231,13 @@ pub struct ImportBuilder {
 }
 
 impl ImportBuilder {
-    pub fn module<T: Into<String>>(&mut self, module: T) -> &mut Self {
-        self.module = Some(module.into());
+    pub fn module<T: AsRef<str>>(&mut self, module: T) -> &mut Self {
+        self.module = Some(module.as_ref().to_string());
         self
     }
 
-    pub fn name<T: Into<String>>(&mut self, name: T) -> &mut Self {
-        self.name = Some(name.into());
+    pub fn name<T: AsRef<str>>(&mut self, name: T) -> &mut Self {
+        self.name = Some(name.as_ref().to_string());
         self
     }
 
@@ -263,8 +263,8 @@ pub struct MemoryDescriptorBuilder {
 }
 
 impl MemoryDescriptorBuilder {
-    pub fn id<T: Into<String>>(&mut self, id: T) -> &mut Self {
-        self.id = Some(Identifier(id.into()));
+    pub fn id<T: AsRef<str>>(&mut self, id: T) -> &mut Self {
+        self.id = Some(Identifier(id.as_ref().to_string()));
         self
     }
 
@@ -295,8 +295,8 @@ pub struct GlobalDescriptorBuilder {
 }
 
 impl GlobalDescriptorBuilder {
-    pub fn id<T: Into<String>>(&mut self, id: T) -> &mut Self {
-        self.id = Some(Identifier(id.into()));
+    pub fn id<T: AsRef<str>>(&mut self, id: T) -> &mut Self {
+        self.id = Some(Identifier(id.as_ref().to_string()));
         self
     }
 
@@ -327,8 +327,8 @@ pub struct FunctionDescriptorBuilder {
 }
 
 impl FunctionDescriptorBuilder {
-    pub fn id<T: Into<String>>(&mut self, id: T) -> &mut Self {
-        self.id = Some(Identifier(id.into()));
+    pub fn id<T: AsRef<str>>(&mut self, id: T) -> &mut Self {
+        self.id = Some(Identifier(id.as_ref().to_string()));
         self
     }
 
@@ -387,8 +387,8 @@ pub struct GlobalBuilder {
 }
 
 impl GlobalBuilder {
-    pub fn id<T: Into<String>>(&mut self, id: T) -> &mut Self {
-        self.id = Some(Identifier(id.into()));
+    pub fn id<T: AsRef<str>>(&mut self, id: T) -> &mut Self {
+        self.id = Some(Identifier(id.as_ref().to_string()));
         self
     }
 
@@ -428,13 +428,13 @@ pub struct FunctionBuilder {
 }
 
 impl FunctionBuilder {
-    pub fn export<T: Into<String>>(&mut self, export: T) -> &mut Self {
-        self.export = Some(export.into());
+    pub fn export<T: AsRef<str>>(&mut self, export: T) -> &mut Self {
+        self.export = Some(export.as_ref().to_string());
         self
     }
 
-    pub fn id<T: Into<String>>(&mut self, id: T) -> &mut Self {
-        self.id = Some(Identifier(id.into()));
+    pub fn id<T: AsRef<str>>(&mut self, id: T) -> &mut Self {
+        self.id = Some(Identifier(id.as_ref().to_string()));
         self
     }
 
@@ -446,9 +446,9 @@ impl FunctionBuilder {
         self
     }
 
-    pub fn named_param<T: Into<String>>(&mut self, name: T, ty: Type) -> &mut Self {
+    pub fn named_param<T: AsRef<str>>(&mut self, name: T, ty: Type) -> &mut Self {
         self.params.push(Param {
-            id: Some(Identifier(name.into())),
+            id: Some(Identifier(name.as_ref().to_string())),
             r#type: ty,
         });
         self
@@ -462,9 +462,9 @@ impl FunctionBuilder {
         self
     }
 
-    pub fn named_local<T: Into<String>>(&mut self, name: T, ty: Type) -> &mut Self {
+    pub fn named_local<T: AsRef<str>>(&mut self, name: T, ty: Type) -> &mut Self {
         self.locals.push(Local {
-            id: Some(Identifier(name.into())),
+            id: Some(Identifier(name.as_ref().to_string())),
             r#type: ty,
         });
         self
@@ -618,33 +618,43 @@ impl InstructionsBuilder {
         self
     }
 
-    pub fn local_get<T: Into<String>>(&mut self, name: T) -> &mut Self {
+    pub fn local_get<T: AsRef<str>>(&mut self, name: T) -> &mut Self {
         self.instructions
-            .push(Instruction::LocalGet(Index::Id(Identifier(name.into()))));
+            .push(Instruction::LocalGet(Index::Id(Identifier(
+                name.as_ref().to_string(),
+            ))));
         self
     }
 
-    pub fn local_set<T: Into<String>>(&mut self, name: T) -> &mut Self {
+    pub fn local_set<T: AsRef<str>>(&mut self, name: T) -> &mut Self {
         self.instructions
-            .push(Instruction::LocalSet(Index::Id(Identifier(name.into()))));
+            .push(Instruction::LocalSet(Index::Id(Identifier(
+                name.as_ref().to_string(),
+            ))));
         self
     }
 
-    pub fn local_tee<T: Into<String>>(&mut self, name: T) -> &mut Self {
+    pub fn local_tee<T: AsRef<str>>(&mut self, name: T) -> &mut Self {
         self.instructions
-            .push(Instruction::LocalTee(Index::Id(Identifier(name.into()))));
+            .push(Instruction::LocalTee(Index::Id(Identifier(
+                name.as_ref().to_string(),
+            ))));
         self
     }
 
-    pub fn global_get<T: Into<String>>(&mut self, name: T) -> &mut Self {
+    pub fn global_get<T: AsRef<str>>(&mut self, name: T) -> &mut Self {
         self.instructions
-            .push(Instruction::GlobalGet(Index::Id(Identifier(name.into()))));
+            .push(Instruction::GlobalGet(Index::Id(Identifier(
+                name.as_ref().to_string(),
+            ))));
         self
     }
 
-    pub fn global_set<T: Into<String>>(&mut self, name: T) -> &mut Self {
+    pub fn global_set<T: AsRef<str>>(&mut self, name: T) -> &mut Self {
         self.instructions
-            .push(Instruction::GlobalSet(Index::Id(Identifier(name.into()))));
+            .push(Instruction::GlobalSet(Index::Id(Identifier(
+                name.as_ref().to_string(),
+            ))));
         self
     }
 
@@ -669,14 +679,17 @@ impl InstructionsBuilder {
         self
     }
 
-    pub fn call<T: Into<String>>(&mut self, name: T) -> &mut Self {
+    pub fn call<T: AsRef<str>>(&mut self, name: T) -> &mut Self {
         self.instructions
-            .push(Instruction::Call(Index::Id(Identifier(name.into()))));
+            .push(Instruction::Call(Index::Id(Identifier(
+                name.as_ref().to_string(),
+            ))));
         self
     }
 
-    pub fn comment<T: Into<String>>(&mut self, comment: T) -> &mut Self {
-        self.instructions.push(Instruction::Comment(comment.into()));
+    pub fn comment<T: AsRef<str>>(&mut self, comment: T) -> &mut Self {
+        self.instructions
+            .push(Instruction::Comment(comment.as_ref().to_string()));
         self
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
     };
 
     let mut tokenizer = Tokenizer::from_string(&src);
-    let mut parser = Parser::new();
+    let parser = Parser::new();
     let mut module = parser.parse(&mut tokenizer);
 
     let mut passes = CompilerPasses::new();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -251,13 +251,7 @@ impl Parser {
             let params = param_names
                 .iter()
                 .zip(&param_types)
-                .map(|(name, ty)| {
-                    wrap(sem::Binding::Variable {
-                        name: name.clone(),
-                        r#type: Rc::clone(ty),
-                        storage: None,
-                    })
-                })
+                .map(|(name, ty)| wrap(sem::Binding::typed_name(name, &ty)))
                 .collect::<Vec<_>>();
 
             let function_type = wrap(sem::Type::Function {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -123,9 +123,6 @@ pub struct CaseArm {
 #[derive(Debug)]
 pub struct Parser {
     naming: PrefixNaming,
-    // This is the environment that will be used as a placeholder
-    // until the correct scope chain is assigned in the semantic analysis.
-    empty_env: Rc<RefCell<sem::Environment>>,
 }
 
 impl Default for Parser {
@@ -138,7 +135,6 @@ impl Parser {
     pub fn new() -> Self {
         Self {
             naming: PrefixNaming::new("?"),
-            empty_env: Rc::new(RefCell::new(sem::Environment::new())),
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -439,7 +439,7 @@ impl Parser {
             match token {
                 Token::Char('[') => {
                     consume_char(tokenizer, '[');
-                    let mut arguments = self.parse_elements(tokenizer, ']');
+                    let mut arguments = self.parse_expr_elements(tokenizer, ']');
                     consume_char(tokenizer, ']');
 
                     if arguments.len() != 1 {
@@ -474,7 +474,7 @@ impl Parser {
             }
             Token::Char('[') => {
                 consume_char(tokenizer, '[');
-                let elements = self.parse_elements(tokenizer, ']');
+                let elements = self.parse_expr_elements(tokenizer, ']');
                 consume_char(tokenizer, ']');
 
                 Some(self.typed_expr(Expr::Array {
@@ -490,7 +490,7 @@ impl Parser {
                 // TODO: Move to parse_access()
                 if let Some(Token::Char('(')) = tokenizer.peek() {
                     consume_char(tokenizer, '(');
-                    let arguments = self.parse_elements(tokenizer, ')');
+                    let arguments = self.parse_expr_elements(tokenizer, ')');
                     consume_char(tokenizer, ')');
 
                     Some(self.typed_expr(Expr::Invocation {
@@ -690,7 +690,7 @@ impl Parser {
         }
     }
 
-    fn parse_elements(
+    fn parse_expr_elements(
         &mut self,
         tokenizer: &mut Peekable<&mut Tokenizer>,
         stop_char: char,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,7 +22,7 @@ pub struct Function {
     pub export: bool,
     // metadata
     pub params: Vec<Rc<RefCell<sem::Binding>>>,
-    pub locals: Vec<Rc<RefCell<asm::LocalStorage>>>,
+    pub locals: Vec<Rc<asm::LocalStorage>>,
     pub r#type: Rc<RefCell<sem::Type>>,
     // The total size of stack frame required for executing this function.
     // It will be calculated by allocator.
@@ -95,7 +95,7 @@ pub enum Expr {
     },
     Case {
         head: Box<Node>, // head expression
-        head_storage: Option<Rc<RefCell<asm::LocalStorage>>>,
+        head_storage: Option<Rc<asm::LocalStorage>>,
         arms: Vec<CaseArm>,
         else_body: Option<Vec<Node>>,
     },

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -120,30 +120,47 @@ pub struct CaseArm {
     pub then_body: Vec<Node>,
 }
 
+#[derive(Debug, Default)]
+pub struct Parser {}
+
 #[derive(Debug)]
-pub struct Parser {
+struct ParserContext {
     naming: PrefixNaming,
 }
 
-impl Default for Parser {
-    fn default() -> Self {
-        Self::new()
+impl ParserContext {
+    pub fn typed_expr(&mut self, expr: Expr) -> Node {
+        let ty = match expr {
+            Expr::Integer(_) => wrap(sem::Type::Int32),
+            Expr::String { .. } => wrap(sem::Type::String),
+            Expr::Stmt(..) => wrap(sem::Type::Void),
+            _ => self.type_var(),
+        };
+
+        Node { expr, r#type: ty }
+    }
+
+    /// Returns a new type variable.
+    pub fn type_var(&mut self) -> Rc<RefCell<sem::Type>> {
+        let name = self.naming.next();
+        wrap(sem::Type::new_type_var(&name))
     }
 }
 
 impl Parser {
     pub fn new() -> Self {
-        Self {
-            naming: PrefixNaming::new("?"),
-        }
+        Self::default()
     }
 
-    pub fn parse(&mut self, tokenizer: &mut Tokenizer) -> Box<Module> {
+    pub fn parse(&self, tokenizer: &mut Tokenizer) -> Box<Module> {
         let mut tokenizer = tokenizer.peekable();
+        let mut context = ParserContext {
+            naming: PrefixNaming::new("?"),
+        };
 
         let mut functions = vec![];
 
-        while let Some(function) = self.parse_function(&mut tokenizer) {
+        while let Some(function) = self.parse_function(&mut tokenizer, &mut context) {
             functions.push(function);
         }
 
@@ -151,11 +168,11 @@ impl Parser {
         // `main` function which is the entry point of a program.
         let mut body = vec![];
 
-        while let Some(expr) = self.parse_stmt(&mut tokenizer) {
+        while let Some(expr) = self.parse_stmt(&mut tokenizer, &mut context) {
             body.push(Some(expr));
         }
 
-        let body = self.wrap_stmts(&mut body);
+        let body = self.wrap_stmts(&mut body, &mut context);
 
         let main = if !body.is_empty() {
             let fun = Function {
@@ -166,7 +183,7 @@ impl Parser {
                 locals: vec![],
                 r#type: wrap(sem::Type::Function {
                     params: vec![],
-                    return_type: self.type_var(),
+                    return_type: context.type_var(),
                 }),
                 frame: None,
             };
@@ -183,7 +200,11 @@ impl Parser {
         })
     }
 
-    fn parse_function(&mut self, tokenizer: &mut Peekable<&mut Tokenizer>) -> Option<Function> {
+    fn parse_function(
+        &self,
+        tokenizer: &mut Peekable<&mut Tokenizer>,
+        context: &mut ParserContext,
+    ) -> Option<Function> {
         // modifiers
         let export = match tokenizer.peek() {
             Some(Token::Export) => {
@@ -233,19 +254,19 @@ impl Parser {
                 _ => {}
             };
 
-            match self.parse_stmt(tokenizer) {
+            match self.parse_stmt(tokenizer, context) {
                 None => break,
                 Some(node) => body.push(Some(node)),
             };
         }
         consume_token(tokenizer, Token::End);
 
-        let body = self.wrap_stmts(&mut body);
+        let body = self.wrap_stmts(&mut body, context);
 
         {
             let param_types = param_names
                 .iter()
-                .map(|_| self.type_var())
+                .map(|_| context.type_var())
                 .collect::<Vec<_>>();
 
             let params = param_names
@@ -256,7 +277,7 @@ impl Parser {
 
             let function_type = wrap(sem::Type::Function {
                 params: param_types,
-                return_type: self.type_var(),
+                return_type: context.type_var(),
             });
 
             let function = Function {
@@ -274,52 +295,67 @@ impl Parser {
     }
 
     /// Returns `Stmt` if the result of `parse_stmt_expr()` is a variable binding.
-    fn parse_stmt(&mut self, tokenizer: &mut Peekable<&mut Tokenizer>) -> Option<Node> {
-        let node = match self.parse_stmt_expr(tokenizer) {
+    fn parse_stmt(
+        &self,
+        tokenizer: &mut Peekable<&mut Tokenizer>,
+        context: &mut ParserContext,
+    ) -> Option<Node> {
+        let node = match self.parse_stmt_expr(tokenizer, context) {
             Some(node) => node,
             None => return None,
         };
 
         if let Expr::Var { .. } = node.expr {
-            return Some(self.wrap_stmt(node));
+            return Some(self.wrap_stmt(node, context));
         }
 
         Some(node)
     }
 
     /// Variable binding or `Expr`
-    fn parse_stmt_expr(&mut self, tokenizer: &mut Peekable<&mut Tokenizer>) -> Option<Node> {
+    fn parse_stmt_expr(
+        &self,
+        tokenizer: &mut Peekable<&mut Tokenizer>,
+        context: &mut ParserContext,
+    ) -> Option<Node> {
         match tokenizer.peek() {
             Some(Token::Let) => {
                 tokenizer.next();
             }
-            _ => return self.parse_expr(tokenizer),
+            _ => return self.parse_expr(tokenizer, context),
         };
 
         // Variable binding - Pattern
-        let pattern = self
-            .parse_pattern(tokenizer)
-            .unwrap_or_else(|| panic!("Missing pattern in `let`"));
+        let pattern =
+            parse_pattern(tokenizer, context).unwrap_or_else(|| panic!("Missing pattern in `let`"));
 
         consume_char(tokenizer, '=');
 
         let init = self
-            .parse_expr(tokenizer)
+            .parse_expr(tokenizer, context)
             .unwrap_or_else(|| panic!("No initializer"));
 
-        Some(self.typed_expr(Expr::Var {
+        Some(context.typed_expr(Expr::Var {
             pattern,
             init: Box::new(init),
         }))
     }
 
-    fn parse_expr(&mut self, tokenizer: &mut Peekable<&mut Tokenizer>) -> Option<Node> {
-        self.parse_relop1(tokenizer)
+    fn parse_expr(
+        &self,
+        tokenizer: &mut Peekable<&mut Tokenizer>,
+        context: &mut ParserContext,
+    ) -> Option<Node> {
+        self.parse_relop1(tokenizer, context)
     }
 
     // "==", "!="
-    fn parse_relop1(&mut self, tokenizer: &mut Peekable<&mut Tokenizer>) -> Option<Node> {
-        let lhs = match self.parse_relop2(tokenizer) {
+    fn parse_relop1(
+        &self,
+        tokenizer: &mut Peekable<&mut Tokenizer>,
+        context: &mut ParserContext,
+    ) -> Option<Node> {
+        let lhs = match self.parse_relop2(tokenizer, context) {
             Some(lhs) => lhs,
             None => return None,
         };
@@ -331,17 +367,21 @@ impl Parser {
         };
         tokenizer.next();
 
-        let rhs = match self.parse_relop2(tokenizer) {
+        let rhs = match self.parse_relop2(tokenizer, context) {
             None => panic!("Expected RHS"),
             Some(rhs) => rhs,
         };
 
-        Some(self.typed_expr(builder(Box::new(lhs), Box::new(rhs), None)))
+        Some(context.typed_expr(builder(Box::new(lhs), Box::new(rhs), None)))
     }
 
     // ">", "<", ">=", "<="
-    fn parse_relop2(&mut self, tokenizer: &mut Peekable<&mut Tokenizer>) -> Option<Node> {
-        let lhs = match self.parse_binop1(tokenizer) {
+    fn parse_relop2(
+        &self,
+        tokenizer: &mut Peekable<&mut Tokenizer>,
+        context: &mut ParserContext,
+    ) -> Option<Node> {
+        let lhs = match self.parse_binop1(tokenizer, context) {
             Some(lhs) => lhs,
             None => return None,
         };
@@ -355,16 +395,20 @@ impl Parser {
         };
         tokenizer.next();
 
-        let rhs = match self.parse_binop1(tokenizer) {
+        let rhs = match self.parse_binop1(tokenizer, context) {
             None => panic!("Expected RHS"),
             Some(rhs) => rhs,
         };
 
-        Some(self.typed_expr(builder(Box::new(lhs), Box::new(rhs), None)))
+        Some(context.typed_expr(builder(Box::new(lhs), Box::new(rhs), None)))
     }
 
-    fn parse_binop1(&mut self, tokenizer: &mut Peekable<&mut Tokenizer>) -> Option<Node> {
-        let mut lhs = match self.parse_binop2(tokenizer) {
+    fn parse_binop1(
+        &self,
+        tokenizer: &mut Peekable<&mut Tokenizer>,
+        context: &mut ParserContext,
+    ) -> Option<Node> {
+        let mut lhs = match self.parse_binop2(tokenizer, context) {
             None => return None,
             Some(lhs) => lhs,
         };
@@ -379,19 +423,23 @@ impl Parser {
             };
             tokenizer.next();
 
-            let rhs = match self.parse_binop2(tokenizer) {
+            let rhs = match self.parse_binop2(tokenizer, context) {
                 None => panic!("Expected RHS"),
                 Some(rhs) => rhs,
             };
 
-            lhs = self.typed_expr(builder(Box::new(lhs), Box::new(rhs), None));
+            lhs = context.typed_expr(builder(Box::new(lhs), Box::new(rhs), None));
         }
 
         Some(lhs)
     }
 
-    fn parse_binop2(&mut self, tokenizer: &mut Peekable<&mut Tokenizer>) -> Option<Node> {
-        let mut lhs = match self.parse_access(tokenizer) {
+    fn parse_binop2(
+        &self,
+        tokenizer: &mut Peekable<&mut Tokenizer>,
+        context: &mut ParserContext,
+    ) -> Option<Node> {
+        let mut lhs = match self.parse_access(tokenizer, context) {
             None => return None,
             Some(lhs) => lhs,
         };
@@ -405,20 +453,24 @@ impl Parser {
             };
             tokenizer.next();
 
-            let rhs = match self.parse_access(tokenizer) {
+            let rhs = match self.parse_access(tokenizer, context) {
                 None => panic!("Expected RHS"),
                 Some(rhs) => rhs,
             };
 
-            lhs = self.typed_expr(builder(Box::new(lhs), Box::new(rhs), None));
+            lhs = context.typed_expr(builder(Box::new(lhs), Box::new(rhs), None));
         }
 
         Some(lhs)
     }
 
     // `... [...]`, `... (...)`
-    fn parse_access(&mut self, tokenizer: &mut Peekable<&mut Tokenizer>) -> Option<Node> {
-        let mut node = self.parse_primary(tokenizer)?;
+    fn parse_access(
+        &self,
+        tokenizer: &mut Peekable<&mut Tokenizer>,
+        context: &mut ParserContext,
+    ) -> Option<Node> {
+        let mut node = self.parse_primary(tokenizer, context)?;
 
         loop {
             let token = match tokenizer.peek() {
@@ -429,10 +481,11 @@ impl Parser {
             match token {
                 Token::Char('[') => {
                     consume_char(tokenizer, '[');
-                    let mut arguments = parse_elements(tokenizer, ']', &mut |tokenizer| {
-                        self.parse_expr(tokenizer)
-                            .expect("Expected subscript argument")
-                    });
+                    let mut arguments =
+                        parse_elements(tokenizer, context, ']', &mut |tokenizer, context| {
+                            self.parse_expr(tokenizer, context)
+                                .expect("Expected subscript argument")
+                        });
                     consume_char(tokenizer, ']');
 
                     if arguments.len() != 1 {
@@ -442,7 +495,7 @@ impl Parser {
                         );
                     }
 
-                    node = self.typed_expr(Expr::Subscript {
+                    node = context.typed_expr(Expr::Subscript {
                         operand: Box::new(node),
                         index: Box::new(arguments.remove(0)),
                     });
@@ -452,7 +505,11 @@ impl Parser {
         }
     }
 
-    fn parse_primary(&mut self, tokenizer: &mut Peekable<&mut Tokenizer>) -> Option<Node> {
+    fn parse_primary(
+        &self,
+        tokenizer: &mut Peekable<&mut Tokenizer>,
+        context: &mut ParserContext,
+    ) -> Option<Node> {
         let token = match tokenizer.peek() {
             None => return None,
             Some(token) => token,
@@ -461,18 +518,20 @@ impl Parser {
         match token {
             Token::Char('(') => {
                 consume_char(tokenizer, '(');
-                let node = self.parse_expr(tokenizer);
+                let node = self.parse_expr(tokenizer, context);
                 consume_char(tokenizer, ')');
                 node
             }
             Token::Char('[') => {
                 consume_char(tokenizer, '[');
-                let elements = parse_elements(tokenizer, ']', &mut |tokenizer| {
-                    self.parse_expr(tokenizer).expect("Expected element")
-                });
+                let elements =
+                    parse_elements(tokenizer, context, ']', &mut |tokenizer, context| {
+                        self.parse_expr(tokenizer, context)
+                            .expect("Expected element")
+                    });
                 consume_char(tokenizer, ']');
 
-                Some(self.typed_expr(Expr::Array {
+                Some(context.typed_expr(Expr::Array {
                     elements,
                     object_offset: None,
                 }))
@@ -485,18 +544,20 @@ impl Parser {
                 // TODO: Move to parse_access()
                 if let Some(Token::Char('(')) = tokenizer.peek() {
                     consume_char(tokenizer, '(');
-                    let arguments = parse_elements(tokenizer, ')', &mut |tokenizer| {
-                        self.parse_expr(tokenizer).expect("Expected argument")
-                    });
+                    let arguments =
+                        parse_elements(tokenizer, context, ')', &mut |tokenizer, context| {
+                            self.parse_expr(tokenizer, context)
+                                .expect("Expected argument")
+                        });
                     consume_char(tokenizer, ')');
 
-                    Some(self.typed_expr(Expr::Invocation {
+                    Some(context.typed_expr(Expr::Invocation {
                         name,
                         arguments,
                         binding: None,
                     }))
                 } else {
-                    Some(self.typed_expr(Expr::Identifier {
+                    Some(context.typed_expr(Expr::Identifier {
                         name,
                         binding: None,
                     }))
@@ -505,7 +566,7 @@ impl Parser {
             Token::Integer(i) => {
                 let expr = Expr::Integer(*i);
                 tokenizer.next();
-                Some(self.typed_expr(expr))
+                Some(context.typed_expr(expr))
             }
             Token::String(s) => {
                 let expr = Expr::String {
@@ -513,12 +574,14 @@ impl Parser {
                     storage: None,
                 };
                 tokenizer.next();
-                Some(self.typed_expr(expr))
+                Some(context.typed_expr(expr))
             }
             Token::If => {
                 tokenizer.next();
 
-                let condition = self.parse_expr(tokenizer).expect("missing condition");
+                let condition = self
+                    .parse_expr(tokenizer, context)
+                    .expect("missing condition");
                 // TODO: check line separator before reading body
 
                 let mut then_body = vec![];
@@ -531,14 +594,14 @@ impl Parser {
                         Some(Token::End) => break,
                         _ => {
                             let stmt = self
-                                .parse_stmt(tokenizer)
+                                .parse_stmt(tokenizer, context)
                                 .unwrap_or_else(|| panic!("Premature EOF"));
                             then_body.push(Some(stmt));
                         }
                     };
                 }
 
-                let then_body = self.wrap_stmts(&mut then_body);
+                let then_body = self.wrap_stmts(&mut then_body, context);
 
                 if let Some(Token::Else) = tokenizer.peek() {
                     let mut body = vec![];
@@ -550,12 +613,12 @@ impl Parser {
                         match tokenizer.peek() {
                             None => panic!("Premature EOF"),
                             Some(Token::End) => {
-                                else_body.replace(self.wrap_stmts(&mut body));
+                                else_body.replace(self.wrap_stmts(&mut body, context));
                                 break;
                             }
                             _ => {
                                 let stmt = self
-                                    .parse_stmt(tokenizer)
+                                    .parse_stmt(tokenizer, context)
                                     .unwrap_or_else(|| panic!("Premature EOF"));
                                 body.push(Some(stmt));
                             }
@@ -570,13 +633,13 @@ impl Parser {
                     else_body,
                 };
 
-                Some(self.typed_expr(expr))
+                Some(context.typed_expr(expr))
             }
             Token::Case => {
                 tokenizer.next();
 
                 let head = self
-                    .parse_expr(tokenizer)
+                    .parse_expr(tokenizer, context)
                     .expect("Missing head expression after `case`");
 
                 // when, ...
@@ -586,8 +649,7 @@ impl Parser {
                     tokenizer.next();
 
                     // pattern
-                    let pattern = self
-                        .parse_pattern(tokenizer)
+                    let pattern = parse_pattern(tokenizer, context)
                         .unwrap_or_else(|| panic!("Missing pattern in `when`"));
 
                     // guard
@@ -595,7 +657,7 @@ impl Parser {
                         Some(Token::If) => {
                             tokenizer.next();
                             let cond = self
-                                .parse_expr(tokenizer)
+                                .parse_expr(tokenizer, context)
                                 .expect("Missing condition in `when if ...`");
                             Some(cond)
                         }
@@ -613,14 +675,14 @@ impl Parser {
                             Some(Token::End) => break,
                             _ => {
                                 let stmt = self
-                                    .parse_stmt(tokenizer)
+                                    .parse_stmt(tokenizer, context)
                                     .unwrap_or_else(|| panic!("Premature EOF"));
                                 then_body.push(Some(stmt));
                             }
                         };
                     }
 
-                    let then_body = self.wrap_stmts(&mut then_body);
+                    let then_body = self.wrap_stmts(&mut then_body, context);
 
                     arms.push(CaseArm {
                         pattern,
@@ -640,13 +702,13 @@ impl Parser {
                         match tokenizer.peek() {
                             None => panic!("Premature EOF"),
                             Some(Token::End) => {
-                                let body = self.wrap_stmts(&mut body);
+                                let body = self.wrap_stmts(&mut body, context);
                                 else_body.replace(body);
                                 break;
                             }
                             _ => {
                                 let stmt = self
-                                    .parse_stmt(tokenizer)
+                                    .parse_stmt(tokenizer, context)
                                     .unwrap_or_else(|| panic!("Premature EOF"));
                                 body.push(Some(stmt));
                             }
@@ -665,36 +727,68 @@ impl Parser {
                     arms,
                     else_body,
                 };
-                Some(self.typed_expr(expr))
+                Some(context.typed_expr(expr))
             }
             token => panic!("Unexpected token {:?}", token),
         }
     }
+}
 
-    fn parse_pattern(&mut self, tokenizer: &mut Peekable<&mut Tokenizer>) -> Option<Pattern> {
-        match tokenizer.peek() {
-            Some(Token::Identifier(ref name)) => {
-                let pat = Pattern::Variable(name.clone(), None);
-                tokenizer.next();
-                Some(pat)
-            }
-            Some(Token::Integer(i)) => {
-                let pat = Pattern::Integer(*i);
-                tokenizer.next();
-                Some(pat)
-            }
-            _ => None,
+impl Parser {
+    // Wrap an expression with statement if it is not statement.
+    fn wrap_stmt(&self, node: Node, context: &mut ParserContext) -> Node {
+        if let Expr::Stmt(..) = node.expr {
+            // Don't wrap stmt with stmt.
+            return node;
         }
+
+        context.typed_expr(Expr::Stmt(Box::new(node)))
+    }
+
+    // Wrap an expressions with statements if it is not the last one.
+    fn wrap_stmts(&self, nodes: &mut Vec<Option<Node>>, context: &mut ParserContext) -> Vec<Node> {
+        let mut stmts = vec![];
+        let mut it = nodes.iter_mut().peekable();
+
+        while let Some(node) = it.next() {
+            if it.peek().is_none() {
+                stmts.push(node.take().unwrap());
+            } else {
+                stmts.push(self.wrap_stmt(node.take().unwrap(), context));
+            }
+        }
+
+        stmts
+    }
+}
+
+fn parse_pattern(
+    tokenizer: &mut Peekable<&mut Tokenizer>,
+    _context: &mut ParserContext,
+) -> Option<Pattern> {
+    match tokenizer.peek() {
+        Some(Token::Identifier(ref name)) => {
+            let pat = Pattern::Variable(name.clone(), None);
+            tokenizer.next();
+            Some(pat)
+        }
+        Some(Token::Integer(i)) => {
+            let pat = Pattern::Integer(*i);
+            tokenizer.next();
+            Some(pat)
+        }
+        _ => None,
     }
 }
 
 fn parse_elements<F, T>(
     tokenizer: &mut Peekable<&mut Tokenizer>,
+    context: &mut ParserContext,
     stop_char: char,
     parser: &mut F,
 ) -> Vec<T>
 where
-    F: FnMut(&mut Peekable<&mut Tokenizer>) -> T,
+    F: Fn(&mut Peekable<&mut Tokenizer>, &mut ParserContext) -> T,
 {
     let mut elements = vec![];
 
@@ -709,7 +803,7 @@ where
             _ => {}
         };
 
-        let element = parser(tokenizer);
+        let element = parser(tokenizer, context);
         elements.push(element);
 
         if let Some(Token::Char(',')) = tokenizer.peek() {
@@ -722,54 +816,9 @@ where
     elements
 }
 
-impl Parser {
-    // Wrap an expression with statement if it is not statement.
-    fn wrap_stmt(&mut self, node: Node) -> Node {
-        if let Expr::Stmt(..) = node.expr {
-            // Don't wrap stmt with stmt.
-            return node;
-        }
-
-        self.typed_expr(Expr::Stmt(Box::new(node)))
-    }
-
-    // Wrap an expressions with statements if it is not the last one.
-    fn wrap_stmts(&mut self, nodes: &mut Vec<Option<Node>>) -> Vec<Node> {
-        let mut stmts = vec![];
-        let mut it = nodes.iter_mut().peekable();
-
-        while let Some(node) = it.next() {
-            if it.peek().is_none() {
-                stmts.push(node.take().unwrap());
-            } else {
-                stmts.push(self.wrap_stmt(node.take().unwrap()));
-            }
-        }
-
-        stmts
-    }
-
-    fn typed_expr(&mut self, expr: Expr) -> Node {
-        let ty = match expr {
-            Expr::Integer(_) => wrap(sem::Type::Int32),
-            Expr::String { .. } => wrap(sem::Type::String),
-            Expr::Stmt(..) => wrap(sem::Type::Void),
-            _ => self.type_var(),
-        };
-
-        Node { expr, r#type: ty }
-    }
-
-    /// Returns a new type variable.
-    fn type_var(&mut self) -> Rc<RefCell<sem::Type>> {
-        let name = self.naming.next();
-        wrap(sem::Type::new_type_var(&name))
-    }
-}
-
 pub fn parse_string<S: AsRef<str>>(src: S) -> Box<Module> {
     let mut tokenizer = Tokenizer::from_string(&src);
-    let mut parser = Parser::new();
+    let parser = Parser::new();
     parser.parse(&mut tokenizer)
 }
 

--- a/src/sem/mod.rs
+++ b/src/sem/mod.rs
@@ -253,8 +253,6 @@ enum Space {
 #[derive(Debug, PartialEq, Clone)]
 enum Value {
     Int(i32),
-    Boolean(bool),
-    String(String),
 }
 
 impl Space {
@@ -391,8 +389,8 @@ mod space_tests {
 
     #[test]
     fn boolean_exhaustivity() {
-        let true_space = Space::Something(wrap(Type::Boolean), Value::Boolean(true));
-        let false_space = Space::Something(wrap(Type::Boolean), Value::Boolean(false));
+        let true_space = Space::Something(wrap(Type::Boolean), Value::Int(1));
+        let false_space = Space::Something(wrap(Type::Boolean), Value::Int(0));
         let boolean_space = true_space.union(&false_space);
 
         assert!(true_space.is_subspace_of(&true_space));

--- a/src/sem/mod.rs
+++ b/src/sem/mod.rs
@@ -44,7 +44,7 @@ pub struct Binding {
     // The type of a target being referenced.
     pub r#type: Rc<RefCell<Type>>,
     // The reference to a runtime storage
-    pub storage: Option<Rc<RefCell<asm::LocalStorage>>>,
+    pub storage: Option<Rc<asm::LocalStorage>>,
 }
 
 impl Binding {
@@ -57,10 +57,7 @@ impl Binding {
         Self {
             name: name.as_ref().to_string(),
             r#type: Rc::clone(&function_type),
-            storage: Some(wrap(asm::LocalStorage {
-                name: name.as_ref().to_string(),
-                r#type: Rc::clone(&function_type),
-            })),
+            storage: Some(asm::LocalStorage::shared(name, &function_type)),
         }
     }
 


### PR DESCRIPTION
- [x] Consolidate parsing elements into the generalized `parse_elements` function using a closure.
- [x] Refactor parser internal.
- [x] Remove operations that should not be done by Parser.
- [x] Change `Binding` enum to struct.