### PR TITLE
Set the token position and string length for language server

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1093,13 +1093,10 @@ where
     loop {
         let token = expect_peek(tokenizer);
 
-        match token.kind {
-            TokenKind::Char(c) => {
-                if c == stop_char {
-                    break;
-                }
+        if let TokenKind::Char(c) = token.kind {
+            if c == stop_char {
+                break;
             }
-            _ => {}
         };
 
         let element = parser(tokenizer, context);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -267,7 +267,10 @@ impl Parser {
                 match tokenizer.peek() {
                     None => break,
                     Some(token) => {
-                        panic!("Unrecognized token: {:?}", token)
+                        panic!(
+                            "Unrecognized token: {} at {}",
+                            token.kind, token.range.start
+                        )
                     }
                 }
             }
@@ -515,7 +518,7 @@ impl Parser {
 
         let rhs = self
             .parse_rel_op2(tokenizer, context)
-            .expect("Expected RHS");
+            .expect("Expected RHS at");
 
         Some(context.typed_expr(builder(Box::new(lhs), Box::new(rhs), None)))
     }
@@ -636,7 +639,10 @@ impl Parser {
                 break;
             }
 
-            let token = tokenizer.peek()?;
+            let token = match tokenizer.peek() {
+                Some(token) => token,
+                None => return Some(node),
+            };
 
             match token.kind {
                 TokenKind::Char('[') => {
@@ -1269,6 +1275,7 @@ mod tests {
     fn number_integer() {
         let program = parse_string("42");
         assert!(program.functions.is_empty());
+        assert!(program.main.is_some());
 
         let expr = &program.main.unwrap().body[0].expr;
         assert_matches!(expr, Expr::Integer(42));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -518,7 +518,7 @@ impl Parser {
 
         let rhs = self
             .parse_rel_op2(tokenizer, context)
-            .expect("Expected RHS at");
+            .unwrap_or_else(|| panic!("Expected RHS at {}", tokenizer.current_position()));
 
         Some(context.typed_expr(builder(Box::new(lhs), Box::new(rhs), None)))
     }
@@ -542,7 +542,7 @@ impl Parser {
 
         let rhs = self
             .parse_binary_op1(tokenizer, context)
-            .expect("Expected RHS");
+            .unwrap_or_else(|| panic!("Expected RHS at {}", tokenizer.current_position()));
 
         Some(context.typed_expr(builder(Box::new(lhs), Box::new(rhs), None)))
     }
@@ -571,7 +571,7 @@ impl Parser {
 
             let rhs = self
                 .parse_binary_op2(tokenizer, context)
-                .expect("Expected RHS");
+                .unwrap_or_else(|| panic!("Expected RHS at {}", tokenizer.current_position()));
 
             lhs = context.typed_expr(builder(Box::new(lhs), Box::new(rhs), None));
         }
@@ -597,7 +597,7 @@ impl Parser {
 
             let rhs = self
                 .parse_unary_op(tokenizer, context)
-                .expect("Expected RHS");
+                .unwrap_or_else(|| panic!("Expected RHS at {}", tokenizer.current_position()));
 
             lhs = context.typed_expr(builder(Box::new(lhs), Box::new(rhs), None));
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,9 +1,9 @@
-use crate::asm;
 use crate::asm::wasm;
 use crate::sem;
 use crate::tokenizer::{Token, Tokenizer};
 use crate::util::naming::PrefixNaming;
 use crate::util::wrap;
+use crate::{asm, tokenizer::TokenKind};
 use std::cell::RefCell;
 use std::fmt;
 use std::rc::Rc;
@@ -307,7 +307,7 @@ impl Parser {
         tokenizer: &mut Tokenizer,
         context: &mut ParserContext,
     ) -> Option<StructDefinition> {
-        match_token(tokenizer, Token::Struct)?;
+        match_token(tokenizer, TokenKind::Struct)?;
 
         let name = expect_identifier(tokenizer, "struct name");
 
@@ -369,7 +369,7 @@ impl Parser {
     ) -> Option<TypeAnnotation> {
         let type_annotation = if let Some(name) = match_identifier(tokenizer, "type name") {
             TypeAnnotation::Name(name)
-        } else if match_token(tokenizer, Token::I32).is_some() {
+        } else if match_token(tokenizer, TokenKind::I32).is_some() {
             TypeAnnotation::Builtin(wrap(sem::Type::Int32))
         } else {
             return None;
@@ -384,22 +384,22 @@ impl Parser {
         context: &mut ParserContext,
     ) -> Option<Function> {
         // modifiers
-        let export = match_token(tokenizer, Token::Export).is_some();
+        let export = match_token(tokenizer, TokenKind::Export).is_some();
 
         // fun
-        match_token(tokenizer, Token::Fun)?;
+        match_token(tokenizer, TokenKind::Fun)?;
 
         let name = expect_identifier(tokenizer, "function name");
 
         let mut param_names = vec![];
 
         expect_char(tokenizer, '(');
-        while let Some(Token::Identifier(_)) = tokenizer.peek() {
+        while let Some(TokenKind::Identifier(_)) = tokenizer.peek_kind() {
             let name = expect_identifier(tokenizer, "param");
             param_names.push(name);
 
-            match tokenizer.peek() {
-                Some(Token::Char(',')) => {
+            match tokenizer.peek_kind() {
+                Some(TokenKind::Char(',')) => {
                     tokenizer.next();
                 }
                 _ => break,
@@ -411,9 +411,9 @@ impl Parser {
         let mut body = vec![];
 
         loop {
-            match tokenizer.peek() {
+            match tokenizer.peek_kind() {
                 None => panic!("Premature EOF"),
-                Some(Token::End) => break,
+                Some(TokenKind::End) => break,
                 _ => {}
             };
 
@@ -422,7 +422,7 @@ impl Parser {
                 Some(node) => body.push(Some(node)),
             };
         }
-        expect_token(tokenizer, Token::End);
+        expect_token_with(tokenizer, TokenKind::End);
 
         let body = self.wrap_stmts(&mut body, context);
 
@@ -474,8 +474,8 @@ impl Parser {
         tokenizer: &mut Tokenizer,
         context: &mut ParserContext,
     ) -> Option<Node> {
-        match tokenizer.peek() {
-            Some(Token::Let) => {
+        match tokenizer.peek_kind() {
+            Some(TokenKind::Let) => {
                 tokenizer.next();
             }
             _ => return self.parse_expr(tokenizer, context),
@@ -506,9 +506,9 @@ impl Parser {
     ) -> Option<Node> {
         let lhs = self.parse_rel_op2(tokenizer, context)?;
 
-        let builder = match tokenizer.peek() {
-            Some(Token::Eq) => Expr::Eq,
-            Some(Token::Ne) => Expr::Ne,
+        let builder = match tokenizer.peek_kind() {
+            Some(TokenKind::Eq) => Expr::Eq,
+            Some(TokenKind::Ne) => Expr::Ne,
             _ => return Some(lhs),
         };
         tokenizer.next();
@@ -528,11 +528,11 @@ impl Parser {
     ) -> Option<Node> {
         let lhs = self.parse_binary_op1(tokenizer, context)?;
 
-        let builder = match tokenizer.peek() {
-            Some(Token::Le) => Expr::Le,
-            Some(Token::Ge) => Expr::Ge,
-            Some(Token::Char('<')) => Expr::Lt,
-            Some(Token::Char('>')) => Expr::Gt,
+        let builder = match tokenizer.peek_kind() {
+            Some(TokenKind::Le) => Expr::Le,
+            Some(TokenKind::Ge) => Expr::Ge,
+            Some(TokenKind::Char('<')) => Expr::Lt,
+            Some(TokenKind::Char('>')) => Expr::Gt,
             _ => return Some(lhs),
         };
         tokenizer.next();
@@ -552,10 +552,10 @@ impl Parser {
         let mut lhs = self.parse_binary_op2(tokenizer, context)?;
 
         loop {
-            let builder = match tokenizer.peek() {
-                Some(Token::Char('+')) => Expr::Add,
-                Some(Token::Char('-')) => Expr::Sub,
-                Some(Token::Char('%')) => Expr::Rem,
+            let builder = match tokenizer.peek_kind() {
+                Some(TokenKind::Char('+')) => Expr::Add,
+                Some(TokenKind::Char('-')) => Expr::Sub,
+                Some(TokenKind::Char('%')) => Expr::Rem,
                 _ => break,
             };
 
@@ -584,9 +584,9 @@ impl Parser {
         let mut lhs = self.parse_unary_op(tokenizer, context)?;
 
         loop {
-            let builder = match tokenizer.peek() {
-                Some(Token::Char('*')) => Expr::Mul,
-                Some(Token::Char('/')) => Expr::Div,
+            let builder = match tokenizer.peek_kind() {
+                Some(TokenKind::Char('*')) => Expr::Mul,
+                Some(TokenKind::Char('/')) => Expr::Div,
                 Some(_) => break,
                 None => return Some(lhs),
             };
@@ -607,10 +607,10 @@ impl Parser {
         tokenizer: &mut Tokenizer,
         context: &mut ParserContext,
     ) -> Option<Node> {
-        let builder = match tokenizer.peek() {
+        let builder = match tokenizer.peek_kind() {
             None => return None,
-            Some(Token::Char('+')) => Expr::Plus,
-            Some(Token::Char('-')) => Expr::Minus,
+            Some(TokenKind::Char('+')) => Expr::Plus,
+            Some(TokenKind::Char('-')) => Expr::Minus,
             Some(_) => return self.parse_access(tokenizer, context),
         };
         tokenizer.next();
@@ -636,13 +636,10 @@ impl Parser {
                 break;
             }
 
-            let token = match tokenizer.peek() {
-                None => break,
-                Some(token) => token,
-            };
+            let token = tokenizer.peek()?;
 
-            match token {
-                Token::Char('[') => {
+            match token.kind {
+                TokenKind::Char('[') => {
                     expect_char(tokenizer, '[');
                     let mut arguments =
                         parse_elements(tokenizer, context, ']', &mut |tokenizer, context| {
@@ -663,7 +660,7 @@ impl Parser {
                         index: Box::new(arguments.remove(0)),
                     });
                 }
-                Token::Char('.') => {
+                TokenKind::Char('.') => {
                     expect_char(tokenizer, '.');
 
                     let field = expect_identifier(tokenizer, "field name");
@@ -686,14 +683,14 @@ impl Parser {
     ) -> Option<Node> {
         let token = tokenizer.peek()?;
 
-        match token {
-            Token::Char('(') => {
+        match &token.kind {
+            TokenKind::Char('(') => {
                 expect_char(tokenizer, '(');
                 let node = self.parse_expr(tokenizer, context);
                 expect_char(tokenizer, ')');
                 node
             }
-            Token::Char('[') => {
+            TokenKind::Char('[') => {
                 expect_char(tokenizer, '[');
                 let elements =
                     parse_elements(tokenizer, context, ']', &mut |tokenizer, context| {
@@ -707,12 +704,12 @@ impl Parser {
                     object_offset: None,
                 }))
             }
-            Token::Identifier(_) => {
+            TokenKind::Identifier(_) => {
                 let name = expect_identifier(tokenizer, "id");
 
                 // function invocation?
                 // TODO: Move to parse_access()
-                if let Some(Token::Char('(')) = tokenizer.peek() {
+                if let Some(TokenKind::Char('(')) = tokenizer.peek_kind() {
                     if !tokenizer.is_newline_seen() {
                         expect_char(tokenizer, '(');
                         let arguments =
@@ -730,7 +727,7 @@ impl Parser {
                     }
                 }
                 // struct literal?
-                else if let Some(Token::Char('{')) = tokenizer.peek() {
+                else if let Some(TokenKind::Char('{')) = tokenizer.peek_kind() {
                     if !tokenizer.is_newline_seen() {
                         expect_char(tokenizer, '{');
                         let fields =
@@ -753,12 +750,12 @@ impl Parser {
                     binding: None,
                 }))
             }
-            Token::Integer(i) => {
+            TokenKind::Integer(i) => {
                 let expr = Expr::Integer(*i);
                 tokenizer.next();
                 Some(context.typed_expr(expr))
             }
-            Token::String(_) => {
+            TokenKind::String(_) => {
                 let content = expect_string(tokenizer, "constant");
                 let expr = Expr::String {
                     content,
@@ -766,7 +763,7 @@ impl Parser {
                 };
                 Some(context.typed_expr(expr))
             }
-            Token::If => {
+            TokenKind::If => {
                 tokenizer.next();
 
                 let condition = self
@@ -776,24 +773,26 @@ impl Parser {
                 let mut else_body = None;
 
                 loop {
-                    match tokenizer.peek() {
-                        None => panic!("Premature EOF"),
-                        Some(Token::Else) => break,
-                        Some(Token::End) => break,
+                    let token = expect_peek(tokenizer);
+
+                    match token.kind {
+                        TokenKind::Else => break,
+                        TokenKind::End => break,
                         _ => self.parse_stmts(&mut then_body, tokenizer, context),
                     };
                 }
 
                 let then_body = self.wrap_stmts(&mut then_body, context);
 
-                if let Some(Token::Else) = tokenizer.peek() {
+                if let Some(TokenKind::Else) = tokenizer.peek_kind() {
                     let mut body = vec![];
-                    expect_token(tokenizer, Token::Else);
+                    expect_token_with(tokenizer, TokenKind::Else);
 
                     loop {
-                        match tokenizer.peek() {
-                            None => panic!("Premature EOF"),
-                            Some(Token::End) => {
+                        let token = expect_peek(tokenizer);
+
+                        match token.kind {
+                            TokenKind::End => {
                                 else_body.replace(self.wrap_stmts(&mut body, context));
                                 break;
                             }
@@ -801,7 +800,7 @@ impl Parser {
                         };
                     }
                 }
-                expect_token(tokenizer, Token::End);
+                expect_token_with(tokenizer, TokenKind::End);
 
                 let expr = Expr::If {
                     condition: Box::new(condition),
@@ -811,7 +810,7 @@ impl Parser {
 
                 Some(context.typed_expr(expr))
             }
-            Token::Case => {
+            TokenKind::Case => {
                 tokenizer.next();
 
                 let head = self
@@ -821,7 +820,7 @@ impl Parser {
                 // when, ...
                 let mut arms = vec![];
 
-                while let Some(Token::When) = tokenizer.peek() {
+                while let Some(TokenKind::When) = tokenizer.peek_kind() {
                     tokenizer.next();
 
                     // pattern
@@ -829,8 +828,8 @@ impl Parser {
                         parse_pattern(tokenizer, context).expect("Missing pattern in `when`");
 
                     // guard
-                    let condition = match tokenizer.peek() {
-                        Some(Token::If) => {
+                    let condition = match tokenizer.peek_kind() {
+                        Some(TokenKind::If) => {
                             tokenizer.next();
                             let cond = self
                                 .parse_expr(tokenizer, context)
@@ -843,11 +842,12 @@ impl Parser {
                     let mut then_body = vec![];
 
                     loop {
-                        match tokenizer.peek() {
-                            None => panic!("Premature EOF"),
-                            Some(Token::When) => break,
-                            Some(Token::Else) => break,
-                            Some(Token::End) => break,
+                        let token = expect_peek(tokenizer);
+
+                        match token.kind {
+                            TokenKind::When => break,
+                            TokenKind::Else => break,
+                            TokenKind::End => break,
                             _ => self.parse_stmts(&mut then_body, tokenizer, context),
                         };
                     }
@@ -864,14 +864,15 @@ impl Parser {
                 // else
                 let mut else_body = None;
 
-                if let Some(Token::Else) = tokenizer.peek() {
+                if let Some(TokenKind::Else) = tokenizer.peek_kind() {
                     let mut body = vec![];
                     tokenizer.next();
 
                     loop {
-                        match tokenizer.peek() {
-                            None => panic!("Premature EOF"),
-                            Some(Token::End) => {
+                        let token = expect_peek(tokenizer);
+
+                        match token.kind {
+                            TokenKind::End => {
                                 let body = self.wrap_stmts(&mut body, context);
                                 else_body.replace(body);
                                 break;
@@ -880,7 +881,7 @@ impl Parser {
                         };
                     }
                 }
-                expect_token(tokenizer, Token::End);
+                expect_token_with(tokenizer, TokenKind::End);
 
                 if arms.is_empty() {
                     panic!("At least one arm required for `case`")
@@ -966,23 +967,23 @@ fn parse_pattern_element(
     tokenizer: &mut Tokenizer,
     context: &mut ParserContext,
 ) -> Option<Pattern> {
-    match tokenizer.peek()? {
-        Token::Identifier(_) => {
+    match tokenizer.peek_kind()? {
+        TokenKind::Identifier(_) => {
             let name = expect_identifier(tokenizer, "variable or struct name");
 
-            if let Some(Token::Char('{')) = tokenizer.peek() {
+            if let Some(TokenKind::Char('{')) = tokenizer.peek_kind() {
                 // struct pattern
                 return Some(parse_struct_pattern(Some(name), tokenizer, context));
             }
 
             Some(build_variable_pattern(name, context))
         }
-        Token::Integer(i) => {
+        TokenKind::Integer(i) => {
             let pat = Pattern::Integer(*i);
             tokenizer.next();
             Some(pat)
         }
-        Token::Char('[') => {
+        TokenKind::Char('[') => {
             expect_char(tokenizer, '[');
             let elements = parse_elements(tokenizer, context, ']', &mut |tokenizer, context| {
                 parse_pattern_element(tokenizer, context).expect("Expected pattern")
@@ -1001,13 +1002,13 @@ fn parse_pattern_element(
 
             Some(Pattern::Array(elements))
         }
-        Token::Char('{') => Some(parse_struct_pattern(None, tokenizer, context)),
-        Token::Rest => {
-            expect_token(tokenizer, Token::Rest);
+        TokenKind::Char('{') => Some(parse_struct_pattern(None, tokenizer, context)),
+        TokenKind::Rest => {
+            expect_token_with(tokenizer, TokenKind::Rest);
 
             // Rest pattern can be ignored by expressing `..._` or `...`.
-            match tokenizer.peek() {
-                Some(Token::Identifier(_)) => {
+            match tokenizer.peek_kind() {
+                Some(TokenKind::Identifier(_)) => {
                     let name = expect_identifier(tokenizer, "rest variable");
                     let binding = if name == "_" {
                         wrap(sem::Binding::ignored(&context.type_var()))
@@ -1084,10 +1085,11 @@ where
     let mut elements = vec![];
 
     loop {
-        match tokenizer.peek() {
-            None => panic!("Premature EOF"),
-            Some(Token::Char(c)) => {
-                if *c == stop_char {
+        let token = expect_peek(tokenizer);
+
+        match token.kind {
+            TokenKind::Char(c) => {
+                if c == stop_char {
                     break;
                 }
             }
@@ -1097,7 +1099,7 @@ where
         let element = parser(tokenizer, context);
         elements.push(element);
 
-        if let Some(Token::Char(',')) = tokenizer.peek() {
+        if let Some(TokenKind::Char(',')) = tokenizer.peek_kind() {
             tokenizer.next();
         } else {
             break;
@@ -1107,49 +1109,80 @@ where
     elements
 }
 
-fn expect_token(tokenizer: &mut Tokenizer, expected: Token) {
+fn expect_peek<'a>(tokenizer: &'a mut Tokenizer) -> &'a Token {
+    let position = tokenizer.current_position();
+
+    tokenizer
+        .peek()
+        .unwrap_or_else(|| panic!("Premature EOF at {}", position))
+}
+
+fn expect_token_with(tokenizer: &mut Tokenizer, expected: TokenKind) {
     match tokenizer.next() {
         None => panic!("Premature EOF"),
-        Some(token) if token == expected => {}
-        Some(token) => panic!("Expected token `{}`, but was `{}`", expected, token),
+        Some(token) if token.kind == expected => {}
+        Some(token) => panic!(
+            "Expected token `{}`, but was `{}` at {}",
+            expected, token.kind, token.range.start
+        ),
     }
 }
 
-fn match_token(tokenizer: &mut Tokenizer, expected: Token) -> Option<Token> {
-    match tokenizer.peek() {
-        Some(token) if token == &expected => tokenizer.next(),
-        _ => None,
+fn match_token(tokenizer: &mut Tokenizer, expected: TokenKind) -> Option<Token> {
+    let token = tokenizer.peek()?;
+
+    if token.kind == expected {
+        tokenizer.next()
+    } else {
+        None
     }
 }
 
 fn match_identifier(tokenizer: &mut Tokenizer, node_kind: &str) -> Option<String> {
-    match tokenizer.peek() {
-        Some(Token::Identifier(_)) => Some(expect_identifier(tokenizer, node_kind)),
-        _ => None,
+    let token = tokenizer.peek()?;
+
+    if let TokenKind::Identifier(_) = token.kind {
+        Some(expect_identifier(tokenizer, node_kind))
+    } else {
+        None
     }
 }
 
 fn match_char(tokenizer: &mut Tokenizer, expected: char) -> Option<Token> {
-    match_token(tokenizer, Token::Char(expected))
+    match_token(tokenizer, TokenKind::Char(expected))
 }
 
 fn expect_char(tokenizer: &mut Tokenizer, expected: char) {
-    expect_token(tokenizer, Token::Char(expected));
+    expect_token_with(tokenizer, TokenKind::Char(expected));
 }
 
 fn expect_identifier(tokenizer: &mut Tokenizer, node_kind: &str) -> String {
-    match tokenizer.next() {
-        Some(Token::Identifier(name)) => name,
-        Some(token) => panic!("Expected {}, but found {}", node_kind, token),
-        None => panic!("Premature EOF, no {}", node_kind),
+    let token = tokenizer
+        .next()
+        .unwrap_or_else(|| panic!("Premature EOF, no {}", node_kind));
+
+    if let TokenKind::Identifier(name) = token.kind {
+        name
+    } else {
+        panic!(
+            "Expected {}, but found {} at {}",
+            node_kind, token.kind, token.range.start
+        )
     }
 }
 
 fn expect_string(tokenizer: &mut Tokenizer, node_kind: &str) -> String {
-    match tokenizer.next() {
-        Some(Token::String(s)) => s,
-        Some(token) => panic!("Expected {}, but found {}", node_kind, token),
-        None => panic!("Premature EOF, no {}", node_kind),
+    let token = tokenizer
+        .next()
+        .unwrap_or_else(|| panic!("Premature EOF, no {}", node_kind));
+
+    if let TokenKind::String(s) = token.kind {
+        s
+    } else {
+        panic!(
+            "Expected {}, but found {} at {}",
+            node_kind, token.kind, token.range.start
+        )
     }
 }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,8 +1,32 @@
 use std::fmt;
 use std::{iter::Peekable, str::Chars};
 
-#[derive(Debug, PartialEq)]
-pub enum Token {
+/// Position in a text document expressed as zero-based line and character offset.
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Default)]
+pub struct Position {
+    /// Line position in a document (zero-based).
+    pub line: usize,
+    /// Character offset on a line in a document (zero-based). Assuming that
+    /// the line is represented as a string, the `character` value represents
+    /// the gap between the `character` and `character + 1`.
+    pub character: usize,
+}
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Default)]
+pub struct EffectiveRange {
+    pub length: usize,
+    pub start: Position,
+    pub end: Position,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Token {
+    pub kind: TokenKind,
+    pub range: EffectiveRange,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum TokenKind {
     // Primitive
     Identifier(String),
     Integer(i32),
@@ -33,7 +57,7 @@ pub enum Token {
 }
 
 pub struct Tokenizer<'a> {
-    iter: Peekable<Chars<'a>>,
+    chars: Peekable<Chars<'a>>,
     at_end: bool,
     newline_seen: bool,
     /// Remember a peeked value, even if it was None.
@@ -57,7 +81,7 @@ impl<'a> Tokenizer<'a> {
         let at_end = iter.peek().is_none();
 
         Tokenizer {
-            iter,
+            chars: iter,
             at_end,
             newline_seen: false,
             peeked: None,
@@ -85,60 +109,76 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
+    pub fn peek_kind(&mut self) -> Option<&TokenKind> {
+        self.peek().map(|x| &x.kind)
+    }
+
+    pub fn current_position(&self) -> Position {
+        Position::default()
+    }
+
     fn next_token(&mut self) -> Option<Token> {
         self.skip_white_spaces();
+        self.begin_token();
 
         let nextc = match self.peek_char() {
             None => return None,
             Some(c) => *c,
         };
 
-        let token = match nextc {
+        let kind = match nextc {
             '0'..='9' => self.read_integer(nextc),
             'a'..='z' | 'A'..='Z' | '_' => self.read_name(nextc),
             '!' | '=' | '<' | '>' => self.read_operator(nextc),
             '"' => self.read_string(),
             '.' => self.read_dot(),
             x => {
-                self.iter.next();
-                Token::Char(x)
+                self.chars.next();
+                TokenKind::Char(x)
             }
         };
 
-        Some(token)
+        let range = self.end_token();
+        Some(Token { kind, range })
     }
 
-    fn read_dot(&mut self) -> Token {
-        self.iter.next();
+    fn begin_token(&mut self) {}
+
+    fn end_token(&mut self) -> EffectiveRange {
+        EffectiveRange::default()
+    }
+
+    fn read_dot(&mut self) -> TokenKind {
+        self.chars.next();
 
         match self.peek_char() {
             Some('.') => {
-                self.iter.next();
+                self.chars.next();
                 match self.peek_char() {
                     Some('.') => {
-                        self.iter.next();
-                        Token::Rest
+                        self.chars.next();
+                        TokenKind::Rest
                     }
                     _ => panic!("Unrecognized token `..`"),
                 }
             }
-            _ => Token::Char('.'),
+            _ => TokenKind::Char('.'),
         }
     }
 
-    fn read_string(&mut self) -> Token {
+    fn read_string(&mut self) -> TokenKind {
         let mut string = String::new();
-        self.iter.next();
+        self.chars.next();
 
         loop {
-            match self.iter.peek() {
+            match self.chars.peek() {
                 Some('"') => {
-                    self.iter.next();
+                    self.chars.next();
                     break;
                 }
                 Some('\\') => {
-                    self.iter.next();
-                    let c = match self.iter.peek() {
+                    self.chars.next();
+                    let c = match self.chars.peek() {
                         Some(c) => *c,
                         None => panic!("Premature EOF while reading escape sequence"),
                     };
@@ -151,43 +191,43 @@ impl<'a> Tokenizer<'a> {
                         '\\' => string.push('\\'),
                         c => panic!("Unrecognized escape sequence: \"\\{}\"", c),
                     };
-                    self.iter.next();
+                    self.chars.next();
                 }
                 Some(c) => {
                     string.push(*c);
-                    self.iter.next();
+                    self.chars.next();
                 }
                 None => panic!("Premature EOF while reading string"),
             };
         }
 
-        Token::String(string)
+        TokenKind::String(string)
     }
 
-    fn read_operator(&mut self, nextc: char) -> Token {
+    fn read_operator(&mut self, nextc: char) -> TokenKind {
         let c = nextc;
-        self.iter.next();
+        self.chars.next();
 
         let nextc = match self.peek_char() {
-            None => return Token::Char(nextc),
+            None => return TokenKind::Char(nextc),
             Some(c) => *c,
         };
 
         let token = match (c, nextc) {
-            ('=', '=') => Token::Eq,
-            ('!', '=') => Token::Ne,
-            ('<', '=') => Token::Le,
-            ('>', '=') => Token::Ge,
-            _ => return Token::Char(c),
+            ('=', '=') => TokenKind::Eq,
+            ('!', '=') => TokenKind::Ne,
+            ('<', '=') => TokenKind::Le,
+            ('>', '=') => TokenKind::Ge,
+            _ => return TokenKind::Char(c),
         };
 
-        self.iter.next();
+        self.chars.next();
         token
     }
 
-    fn read_name(&mut self, nextc: char) -> Token {
+    fn read_name(&mut self, nextc: char) -> TokenKind {
         let mut value = nextc.to_string();
-        self.iter.next();
+        self.chars.next();
 
         while let Some(nextc) = self.peek_char() {
             match nextc {
@@ -196,33 +236,33 @@ impl<'a> Tokenizer<'a> {
                 }
                 _ => break,
             };
-            self.iter.next();
+            self.chars.next();
         }
 
         // trailing "!"
         if let Some(nextc @ '!') = self.peek_char() {
             value.push(*nextc);
-            self.iter.next();
+            self.chars.next();
         }
 
         match value.as_str() {
-            "if" => Token::If,
-            "else" => Token::Else,
-            "end" => Token::End,
-            "fun" => Token::Fun,
-            "case" => Token::Case,
-            "when" => Token::When,
-            "export" => Token::Export,
-            "let" => Token::Let,
-            "struct" => Token::Struct,
-            "i32" => Token::I32,
-            _ => Token::Identifier(value),
+            "if" => TokenKind::If,
+            "else" => TokenKind::Else,
+            "end" => TokenKind::End,
+            "fun" => TokenKind::Fun,
+            "case" => TokenKind::Case,
+            "when" => TokenKind::When,
+            "export" => TokenKind::Export,
+            "let" => TokenKind::Let,
+            "struct" => TokenKind::Struct,
+            "i32" => TokenKind::I32,
+            _ => TokenKind::Identifier(value),
         }
     }
 
-    fn read_integer(&mut self, nextc: char) -> Token {
+    fn read_integer(&mut self, nextc: char) -> TokenKind {
         let mut value: i32 = (nextc as i32) - ('0' as i32);
-        self.iter.next();
+        self.chars.next();
 
         loop {
             match self.peek_char() {
@@ -232,15 +272,15 @@ impl<'a> Tokenizer<'a> {
                     value = value * 10 + n;
                 }
                 _ => {
-                    return Token::Integer(value);
+                    return TokenKind::Integer(value);
                 }
             };
-            self.iter.next();
+            self.chars.next();
         }
     }
 
     fn peek_char(&mut self) -> Option<&char> {
-        let c = self.iter.peek();
+        let c = self.chars.peek();
         self.at_end = c.is_none();
         c
     }
@@ -271,33 +311,39 @@ impl<'a> Tokenizer<'a> {
                     }
                 },
             }
-            self.iter.next();
+            self.chars.next();
         }
     }
 }
 
-impl fmt::Display for Token {
+impl fmt::Display for Position {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "line:{}:{}", self.line, self.character)
+    }
+}
+
+impl fmt::Display for TokenKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Token::Identifier(name) => write!(f, "id<{}>", name),
-            Token::Integer(i) => write!(f, "int<{}>", i),
-            Token::String(s) => write!(f, "str<{}>", s),
-            Token::If => write!(f, "if"),
-            Token::Else => write!(f, "else"),
-            Token::End => write!(f, "end"),
-            Token::Fun => write!(f, "fun"),
-            Token::Case => write!(f, "case"),
-            Token::When => write!(f, "when"),
-            Token::Export => write!(f, "export"),
-            Token::Let => write!(f, "let"),
-            Token::Rest => write!(f, "..."),
-            Token::Struct => write!(f, "struct"),
-            Token::I32 => write!(f, "i32"),
-            Token::Eq => write!(f, "=="),
-            Token::Ne => write!(f, "!="),
-            Token::Le => write!(f, "<="),
-            Token::Ge => write!(f, ">="),
-            Token::Char(c) => write!(f, "{}", c),
+            TokenKind::Identifier(name) => write!(f, "id<{}>", name),
+            TokenKind::Integer(i) => write!(f, "int<{}>", i),
+            TokenKind::String(s) => write!(f, "str<{}>", s),
+            TokenKind::If => write!(f, "if"),
+            TokenKind::Else => write!(f, "else"),
+            TokenKind::End => write!(f, "end"),
+            TokenKind::Fun => write!(f, "fun"),
+            TokenKind::Case => write!(f, "case"),
+            TokenKind::When => write!(f, "when"),
+            TokenKind::Export => write!(f, "export"),
+            TokenKind::Let => write!(f, "let"),
+            TokenKind::Rest => write!(f, "..."),
+            TokenKind::Struct => write!(f, "struct"),
+            TokenKind::I32 => write!(f, "i32"),
+            TokenKind::Eq => write!(f, "=="),
+            TokenKind::Ne => write!(f, "!="),
+            TokenKind::Le => write!(f, "<="),
+            TokenKind::Ge => write!(f, ">="),
+            TokenKind::Char(c) => write!(f, "{}", c),
         }
     }
 }
@@ -325,15 +371,78 @@ mod tests {
         let mut tokenizer = Tokenizer::from_string("42() ab_01");
 
         assert!(!tokenizer.is_at_end());
-        assert_matches!(tokenizer.next().unwrap(), Token::Integer(42));
-        assert_matches!(tokenizer.next().unwrap(), Token::Char('('));
-        assert_matches!(tokenizer.next().unwrap(), Token::Char(')'));
+
+        let token = tokenizer.next().unwrap();
+        assert_matches!(token.kind, TokenKind::Integer(42));
+        assert_eq!(
+            token.range,
+            EffectiveRange {
+                start: Position {
+                    line: 0,
+                    character: 0
+                },
+                end: Position {
+                    line: 0,
+                    character: 1
+                },
+                length: 2
+            }
+        );
+
+        let token = tokenizer.next().unwrap();
+        assert_matches!(token.kind, TokenKind::Char('('));
+        assert_eq!(
+            token.range,
+            EffectiveRange {
+                start: Position {
+                    line: 0,
+                    character: 2
+                },
+                end: Position {
+                    line: 0,
+                    character: 2
+                },
+                length: 1
+            }
+        );
+
+        let token = tokenizer.next().unwrap();
+        assert_matches!(token.kind, TokenKind::Char(')'));
+        assert_eq!(
+            token.range,
+            EffectiveRange {
+                start: Position {
+                    line: 0,
+                    character: 3
+                },
+                end: Position {
+                    line: 0,
+                    character: 3
+                },
+                length: 1
+            }
+        );
+
         assert!(!tokenizer.is_at_end());
 
-        assert_matches!(tokenizer.next().unwrap(), Token::Identifier(name) => {
+        let token = tokenizer.next().unwrap();
+        assert_matches!(token.kind, TokenKind::Identifier(name) => {
             assert_eq!(name, "ab_01");
         });
-
+        assert_eq!(
+            token.range,
+            EffectiveRange {
+                start: Position {
+                    line: 0,
+                    character: 5
+                },
+                end: Position {
+                    line: 0,
+                    character: 9
+                },
+                length: 5
+            }
+        );
         assert!(tokenizer.is_at_end());
         assert!(tokenizer.next().is_none());
     }
@@ -342,34 +451,34 @@ mod tests {
     fn operators() {
         let mut tokenizer = Tokenizer::from_string("!===<><=>=");
 
-        assert_matches!(tokenizer.next().unwrap(), Token::Ne);
-        assert_matches!(tokenizer.next().unwrap(), Token::Eq);
-        assert_matches!(tokenizer.next().unwrap(), Token::Char('<'));
-        assert_matches!(tokenizer.next().unwrap(), Token::Char('>'));
-        assert_matches!(tokenizer.next().unwrap(), Token::Le);
-        assert_matches!(tokenizer.next().unwrap(), Token::Ge);
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::Ne);
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::Eq);
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::Char('<'));
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::Char('>'));
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::Le);
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::Ge);
     }
 
     #[test]
     fn keywords() {
         let mut tokenizer = Tokenizer::from_string("if end fun");
 
-        assert_matches!(tokenizer.next().unwrap(), Token::If);
-        assert_matches!(tokenizer.next().unwrap(), Token::End);
-        assert_matches!(tokenizer.next().unwrap(), Token::Fun);
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::If);
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::End);
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::Fun);
     }
 
     #[test]
     fn strings() {
         let mut tokenizer = Tokenizer::from_string("\"\" \"\\n\" \"\\\"\"");
 
-        assert_matches!(tokenizer.next().unwrap(), Token::String(str) => {
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::String(str) => {
             assert_eq!(str, "");
         });
-        assert_matches!(tokenizer.next().unwrap(), Token::String(str) => {
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::String(str) => {
             assert_eq!(str, "\n");
         });
-        assert_matches!(tokenizer.next().unwrap(), Token::String(str) => {
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::String(str) => {
             assert_eq!(str, "\"");
         });
     }
@@ -378,16 +487,16 @@ mod tests {
     fn identifiers() {
         let mut tokenizer = Tokenizer::from_string("abc abc! ab!c");
 
-        assert_matches!(tokenizer.next().unwrap(), Token::Identifier(str) => {
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::Identifier(str) => {
             assert_eq!(str, "abc");
         });
-        assert_matches!(tokenizer.next().unwrap(), Token::Identifier(str) => {
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::Identifier(str) => {
             assert_eq!(str, "abc!");
         });
-        assert_matches!(tokenizer.next().unwrap(), Token::Identifier(str) => {
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::Identifier(str) => {
             assert_eq!(str, "ab!");
         });
-        assert_matches!(tokenizer.next().unwrap(), Token::Identifier(str) => {
+        assert_matches!(tokenizer.next().unwrap().kind, TokenKind::Identifier(str) => {
             assert_eq!(str, "c");
         });
     }
@@ -397,14 +506,14 @@ mod tests {
         let mut tokenizer = Tokenizer::from_string("1 2 3");
 
         // peek() lets us see into the future
-        assert_eq!(tokenizer.peek(), Some(&Token::Integer(1)));
-        assert_eq!(tokenizer.next(), Some(Token::Integer(1)));
-        assert_eq!(tokenizer.next(), Some(Token::Integer(2)));
+        assert_eq!(tokenizer.peek().unwrap().kind, TokenKind::Integer(1));
+        assert_eq!(tokenizer.next().unwrap().kind, TokenKind::Integer(1));
+        assert_eq!(tokenizer.next().unwrap().kind, TokenKind::Integer(2));
 
         // The tokenizer does not advance even if we `peek` multiple times
-        assert_eq!(tokenizer.peek(), Some(&Token::Integer(3)));
-        assert_eq!(tokenizer.peek(), Some(&Token::Integer(3)));
-        assert_eq!(tokenizer.next(), Some(Token::Integer(3)));
+        assert_eq!(tokenizer.peek().unwrap().kind, TokenKind::Integer(3));
+        assert_eq!(tokenizer.peek().unwrap().kind, TokenKind::Integer(3));
+        assert_eq!(tokenizer.next().unwrap().kind, TokenKind::Integer(3));
 
         // After the iterator is finished, so is `peek()`
         assert_eq!(tokenizer.peek(), None);


### PR DESCRIPTION
To integrate with LS semantic tokenizing #67 , make the tokenizer return the location and range of the token. In fact, the nodes need to have the same information, but that is a topic for another time.