### PR TITLE
Add comment token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,5 +31,4 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npm run build --if-present
-      - run: npm test
+      - run: npm run check

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
   },
   "scripts": {
     "nico": "ts-node ./runner/index.ts",
-    "build": "cargo check && cargo clean && cargo clippy -- -D clippy::clone_on_ref_ptr -D clippy::cast_possible_truncation -D warnings -A clippy::match-single-binding && cargo build && cargo test",
+    "lint": "cargo check && cargo clean && cargo clippy -- -D clippy::clone_on_ref_ptr -D clippy::cast_possible_truncation -D warnings -A clippy::match-single-binding && cargo build",
+    "build": "cargo build && cargo test",
     "pretest": "npm run build",
-    "test": "jest"
+    "test": "jest",
+    "check": "npm run lint && npm run test"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1277,6 +1277,7 @@ mod tests {
         let expr = &program.main.unwrap().body[0].expr;
         assert_matches!(expr, Expr::Integer(42));
     }
+
     #[test]
     fn number_integer_followed_by_letter() {
         let program = parse_string("123a");

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -54,6 +54,9 @@ pub enum TokenKind {
     Le, // "<="
     Ge, // ">="
 
+    // comment
+    LineComment(String),
+
     // punctuations
     Char(char),
 }
@@ -364,6 +367,7 @@ impl fmt::Display for TokenKind {
             TokenKind::Identifier(name) => write!(f, "id<{}>", name),
             TokenKind::Integer(i) => write!(f, "int<{}>", i),
             TokenKind::String(s) => write!(f, "str<{}>", s),
+            TokenKind::LineComment(s) => write!(f, "comment<{}>", s),
             TokenKind::If => write!(f, "if"),
             TokenKind::Else => write!(f, "else"),
             TokenKind::End => write!(f, "end"),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -336,7 +336,7 @@ impl<'a> Tokenizer<'a> {
     fn peek_char(&mut self) -> Option<char> {
         let c = self.chars.peek();
         self.at_end = c.is_none();
-        c.map(|c| *c)
+        c.copied()
     }
 
     fn next_char(&mut self) -> Option<char> {


### PR DESCRIPTION
Connect #67 

Added support for tokenizers to return comment tokens. However, Parser is still difficult to deal with, so we also added an option to ignore comment tokens.