### PR TITLE
Remove Rc indirection from syntax token

### DIFF
--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -498,8 +498,6 @@ impl<'a> Parser<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
-
     use super::*;
     use crate::{
         syntax::{ExpressionKind, Statement, TopLevelKind},
@@ -774,25 +772,25 @@ mod tests {
         }
     }
 
-    fn unwrap_interpreted_token(token: &SyntaxToken) -> Rc<Token> {
+    fn unwrap_interpreted_token(token: &SyntaxToken) -> &Token {
         if let SyntaxToken::Interpreted(token) = token {
-            Rc::clone(token)
+            token
         } else {
             panic!("expected interpreted token")
         }
     }
 
-    fn unwrap_missing_token(token: &SyntaxToken) -> Rc<Token> {
+    fn unwrap_missing_token(token: &SyntaxToken) -> &Token {
         if let SyntaxToken::Missing(token) = token {
-            Rc::clone(token)
+            token
         } else {
             panic!("expected missing token")
         }
     }
 
-    fn unwrap_skipped_token(token: &SyntaxToken) -> (Rc<Token>, String) {
+    fn unwrap_skipped_token(token: &SyntaxToken) -> (&Token, String) {
         if let SyntaxToken::Skipped { token, expected } = token {
-            (Rc::clone(token), expected.clone())
+            (token, expected.clone())
         } else {
             panic!("expected skipped token")
         }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -6,8 +6,9 @@
 //! sequences and EOF in the middle.
 //!
 //! It is responsibility of parsers to interpret these tokens and generate strings and other nodes.
-use std::{fmt, rc::Rc};
-use std::{iter::Peekable, str::Chars};
+use std::fmt;
+use std::iter::Peekable;
+use std::str::Chars;
 
 /// Position in a text document expressed as zero-based line and character offset.
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Default)]
@@ -112,17 +113,17 @@ pub enum TokenizerMode {
 
 #[derive(Debug)]
 pub enum SyntaxToken {
-    Interpreted(Rc<Token>),
-    Missing(Rc<Token>),
+    Interpreted(Token),
+    Missing(Token),
     /// A skipped token with the description of an expected node.
     Skipped {
-        token: Rc<Token>,
+        token: Token,
         expected: String,
     },
 }
 
 impl SyntaxToken {
-    pub fn token(&self) -> &Rc<Token> {
+    pub fn token(&self) -> &Token {
         match self {
             SyntaxToken::Interpreted(token)
             | SyntaxToken::Missing(token)
@@ -139,16 +140,16 @@ pub enum SyntaxTokenItem {
 
 impl SyntaxTokenItem {
     pub fn interpreted(token: Token) -> Self {
-        Self::Token(SyntaxToken::Interpreted(Rc::new(token)))
+        Self::Token(SyntaxToken::Interpreted(token))
     }
 
     pub fn missing(token: Token) -> Self {
-        Self::Token(SyntaxToken::Missing(Rc::new(token)))
+        Self::Token(SyntaxToken::Missing(token))
     }
 
     pub fn skipped<S: Into<String>>(token: Token, expected: S) -> Self {
         Self::Token(SyntaxToken::Skipped {
-            token: Rc::new(token),
+            token: token,
             expected: expected.into(),
         })
     }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -149,7 +149,7 @@ impl SyntaxTokenItem {
 
     pub fn skipped<S: Into<String>>(token: Token, expected: S) -> Self {
         Self::Token(SyntaxToken::Skipped {
-            token: token,
+            token,
             expected: expected.into(),
         })
     }


### PR DESCRIPTION
Remove unnecessary indirection from the Syntax Token, since Rc is not used anymore.
