### PR TITLE
Missing token position should be placed at `natural` position

### DIFF
--- a/src/bin/nico-ls.rs
+++ b/src/bin/nico-ls.rs
@@ -1,7 +1,8 @@
 use log::{info, warn};
 use lsp_types::*;
 use nico::syntax::{
-    self, MissingTokenKind, Node, NodePath, ParseError, Parser, Token, TokenKind, Trivia,
+    self, EffectiveRange, MissingTokenKind, Node, NodePath, ParseError, Parser, Token, TokenKind,
+    Trivia,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -143,18 +144,18 @@ impl syntax::Visitor for DiagnosticsCollector {
     fn enter_missing_token(
         &mut self,
         _path: &mut NodePath,
-        position: syntax::Position,
+        range: EffectiveRange,
         item: MissingTokenKind,
     ) {
         let diagnostic = Diagnostic {
             range: Range {
                 start: Position {
-                    line: position.line,
-                    character: position.character.saturating_sub(1),
+                    line: range.start.line,
+                    character: range.start.character,
                 },
                 end: Position {
-                    line: position.line,
-                    character: position.character,
+                    line: range.end.line,
+                    character: range.end.character,
                 },
             },
             severity: Some(DiagnosticSeverity::Error),

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -644,7 +644,7 @@ impl<'a> Parser<'a> {
                 _ => {
                     // Premature EOF or unknown token.
                     code.missing(
-                        self.tokenizer.current_position(),
+                        self.tokenizer.current_insertion_range().start,
                         MissingTokenKind::Char(close_char),
                     );
                     break;
@@ -1028,8 +1028,8 @@ mod tests {
 
         let (position, item) = unwrap_missing_token(tokens[3]);
         assert_eq!(item, MissingTokenKind::Char(']'));
-        assert_eq!(position.line, 1);
-        assert_eq!(position.character, 1);
+        assert_eq!(position.line, 0);
+        assert_eq!(position.character, 2);
     }
 
     #[test]
@@ -1048,8 +1048,10 @@ mod tests {
             let tokens = stmt.expression.code().collect::<Vec<_>>();
             assert_eq!(tokens.len(), 4);
 
-            let (_, item) = unwrap_missing_token(tokens[3]);
+            let (position, item) = unwrap_missing_token(tokens[3]);
             assert_eq!(item, MissingTokenKind::Char(']'));
+            assert_eq!(position.line, 0);
+            assert_eq!(position.character, 2);
         }
     }
 

--- a/src/syntax/tokenizer.rs
+++ b/src/syntax/tokenizer.rs
@@ -117,7 +117,7 @@ enum TokenizerMode {
 pub enum SyntaxToken {
     Interpreted(Token),
     Missing {
-        position: Position,
+        range: EffectiveRange,
         item: MissingTokenKind,
     },
     /// A skipped token with the description of an expected node.

--- a/src/syntax/tokenizer.rs
+++ b/src/syntax/tokenizer.rs
@@ -144,6 +144,7 @@ pub struct Tokenizer<'a> {
     chars: Peekable<Chars<'a>>,
     at_end: bool,
     newline_seen: bool,
+    previous_token: Option<Token>,
     /// Tracking the range of token.
     lineno: usize,
     columnno: usize,
@@ -169,6 +170,7 @@ impl<'a> Tokenizer<'a> {
             start_position: None,
             token_text: "".to_string(),
             peeked: None,
+            previous_token: None,
         }
     }
 
@@ -192,6 +194,18 @@ impl<'a> Tokenizer<'a> {
 
     pub fn peek_kind(&mut self) -> &TokenKind {
         &self.peek().kind
+    }
+
+    /// Returns the effective range of the token at the current position that would be
+    /// appropriate if a new token were to be inserted.
+    pub fn current_insertion_range(&self) -> EffectiveRange {
+        if self.newline_seen || self.is_at_end() {
+            if let Some(ref token) = self.previous_token {
+                return token.range;
+            }
+        }
+
+        self.current_range()
     }
 
     pub fn current_position(&self) -> Position {
@@ -230,10 +244,13 @@ impl<'a> Tokenizer<'a> {
     }
 
     pub fn next_token(&mut self) -> Token {
-        match self.peeked.take() {
+        let token = match self.peeked.take() {
             Some(v) => v,
             None => self.advance_token(),
-        }
+        };
+
+        self.previous_token = Some(token.clone());
+        token
     }
 
     fn begin_token(&mut self) {

--- a/src/syntax/traverse.rs
+++ b/src/syntax/traverse.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::syntax::Token;
 use crate::{syntax::tree::*, util::wrap};
 
-use super::{MissingTokenKind, Position, Scope, SyntaxToken, Trivia, TriviaKind};
+use super::{EffectiveRange, MissingTokenKind, Scope, SyntaxToken, Trivia, TriviaKind};
 
 pub struct NodePath {
     skipped: bool,
@@ -132,14 +132,14 @@ pub trait Visitor {
     fn enter_missing_token(
         &mut self,
         path: &mut NodePath,
-        position: Position,
+        range: EffectiveRange,
         item: MissingTokenKind,
     ) {
     }
     fn exit_missing_token(
         &mut self,
         path: &mut NodePath,
-        position: Position,
+        range: EffectiveRange,
         item: MissingTokenKind,
     ) {
     }
@@ -397,8 +397,8 @@ fn traverse_children(visitor: &mut dyn Visitor, path: &Rc<RefCell<NodePath>>) {
                     SyntaxToken::Interpreted(token) => {
                         traverse_interpreted_token(visitor, &mut path, token)
                     }
-                    SyntaxToken::Missing { position, item } => {
-                        traverse_missing_token(visitor, &mut path, *position, *item)
+                    SyntaxToken::Missing { range, item } => {
+                        traverse_missing_token(visitor, &mut path, *range, *item)
                     }
                     SyntaxToken::Skipped { token, expected } => {
                         traverse_skipped_token(visitor, &mut path, token, *expected)
@@ -447,14 +447,14 @@ fn traverse_interpreted_token(visitor: &mut dyn Visitor, path: &mut NodePath, to
 fn traverse_missing_token(
     visitor: &mut dyn Visitor,
     path: &mut NodePath,
-    position: Position,
+    range: EffectiveRange,
     item: MissingTokenKind,
 ) {
     if !path.skipped {
-        visitor.enter_missing_token(path, position, item);
+        visitor.enter_missing_token(path, range, item);
     }
     if !path.skipped {
-        visitor.exit_missing_token(path, position, item);
+        visitor.exit_missing_token(path, range, item);
     }
 }
 

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -1,4 +1,4 @@
-use super::{MissingTokenKind, Position, Scope, SyntaxToken, Token};
+use super::{EffectiveRange, MissingTokenKind, Scope, SyntaxToken, Token};
 use crate::{sem, util::wrap};
 use std::rc::Rc;
 use std::slice;
@@ -361,11 +361,9 @@ impl Code {
         self
     }
 
-    pub fn missing(&mut self, position: Position, item: MissingTokenKind) -> &mut Self {
-        self.code.push(CodeKind::SyntaxToken(SyntaxToken::Missing {
-            position,
-            item,
-        }));
+    pub fn missing(&mut self, range: EffectiveRange, item: MissingTokenKind) -> &mut Self {
+        self.code
+            .push(CodeKind::SyntaxToken(SyntaxToken::Missing { range, item }));
         self
     }
 


### PR DESCRIPTION
Connect #64

In relation to https://github.com/ishikawa/nico/pull/90, a missing token should be placed at one of the following positions:

1. If the next token is met after new line character, a missing token should be placed at the same position of the **previous** token.
2. Otherwise, a missing token should be placed at the same position of the **next** token.
