### PR TITLE
🍣 Type inference for case expression

### DIFF
--- a/src/language_server/description.rs
+++ b/src/language_server/description.rs
@@ -1,5 +1,5 @@
 use crate::semantic::{StructType, TypeKind};
-use crate::syntax::{self, VariablePattern};
+use crate::syntax::{self, TypedNode, VariablePattern};
 use std::fmt::Display;
 
 pub fn code_fence<T: Display>(content: T) -> String {

--- a/src/language_server/hover.rs
+++ b/src/language_server/hover.rs
@@ -2,8 +2,8 @@ use super::description;
 use crate::arena::BumpaloArena;
 use crate::syntax::{
     self, EffectiveRange, FunctionDefinition, FunctionParameter, MemberExpression, Node, NodePath,
-    Position, Program, StructDefinition, StructLiteral, TypeAnnotation, TypeField, ValueField,
-    VariableExpression, VariablePattern,
+    Position, Program, StructDefinition, StructLiteral, TypeAnnotation, TypeField, TypedNode,
+    ValueField, VariableExpression, VariablePattern,
 };
 use crate::unwrap_or_return;
 

--- a/src/language_server/rename.rs
+++ b/src/language_server/rename.rs
@@ -6,7 +6,8 @@ use crate::syntax::TypeField;
 use crate::syntax::ValueField;
 use crate::syntax::{
     self, EffectiveRange, FunctionDefinition, FunctionParameter, Identifier, Node, NodePath,
-    Position, Program, StructDefinition, StructLiteral, VariableExpression, VariablePattern,
+    Position, Program, StructDefinition, StructLiteral, TypedNode, VariableExpression,
+    VariablePattern,
 };
 use crate::unwrap_or_return;
 

--- a/src/semantic/binding.rs
+++ b/src/semantic/binding.rs
@@ -1,6 +1,8 @@
 use crate::arena::{BumpaloArena, BumpaloString};
 use crate::semantic::{self, TypeKind};
-use crate::syntax::{FunctionDefinition, FunctionParameter, StructDefinition, VariablePattern};
+use crate::syntax::{
+    FunctionDefinition, FunctionParameter, StructDefinition, TypedNode, VariablePattern,
+};
 use std::fmt;
 
 use super::{FunctionType, StructType};

--- a/src/semantic/errors.rs
+++ b/src/semantic/errors.rs
@@ -1,4 +1,5 @@
 use super::{Binding, TypeKind};
+use crate::syntax::NodeKind;
 use std::fmt::Display;
 use thiserror::Error;
 
@@ -19,6 +20,13 @@ pub enum SemanticError<'a> {
     },
     #[error("Cannot find name '{name}'.")]
     UndefinedBinding { name: String },
+    #[error("Can not infer type. Consider giving `{node}` the explicit type `{r#type}`, with the type parameters specified.")]
+    CannotInferType {
+        node: NodeKind<'a>,
+        r#type: TypeKind<'a>,
+    },
+    #[error("Unknown field. No field `{field}` on type `{r#type}`")]
+    FieldDoesNotExist { r#type: TypeKind<'a>, field: String },
     #[error("{0}")]
     TypeError(TypeError<'a>),
 }

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -6,7 +6,8 @@ use crate::syntax::{
     self, ArrayExpression, BinaryExpression, CallExpression, CaseExpression, FunctionDefinition,
     GroupedExpression, IfExpression, MemberExpression, Node, NodePath, PatternKind,
     StructDefinition, StructLiteral, SubscriptExpression, TypeAnnotation, TypeAnnotationKind,
-    UnaryExpression, ValueField, VariableDeclaration, VariableExpression, VariablePattern, Visitor,
+    TypedNode, UnaryExpression, ValueField, VariableDeclaration, VariableExpression,
+    VariablePattern, Visitor,
 };
 use crate::unwrap_or_return;
 use log::debug;
@@ -1338,6 +1339,7 @@ impl<'a> Visitor<'a> for TypeInferencer<'a> {
 
 /// Indirect references by type variables are still necessary after type inference is complete.
 /// However, unnecessary indirect references can be removed.
+/// Furthermore, raise error if there are any type variables still left at the leaf node.
 #[derive(Debug)]
 pub(super) struct TypeVariablePruner<'a> {
     arena: &'a BumpaloArena,

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -994,14 +994,6 @@ impl<'a> Visitor<'a> for InitialTypeBinder<'a> {
     ) {
         pattern.assign_type(TypeKind::TypeVariable(self.new_type_var()));
     }
-
-    fn exit_value_field_pattern(
-        &mut self,
-        _path: &'a NodePath<'a>,
-        pattern: &'a syntax::ValueFieldPattern<'a>,
-    ) {
-        pattern.assign_type(TypeKind::TypeVariable(self.new_type_var()))
-    }
 }
 
 #[derive(Debug)]
@@ -1362,7 +1354,11 @@ impl<'a> Visitor<'a> for TypeInferencer<'a> {
             .array_type()
             .expect("The type of an array pattern must be an array type.");
 
-        for element in pattern.elements() {
+        debug!("[inference] array pattern: {}", pattern);
+
+        for (i, element) in pattern.elements().enumerate() {
+            debug!("[inference] #{} of array pattern: {}", i, element);
+
             if element.rest_pattern().is_some() {
                 if let Err(err) = element.r#type().unify(self.arena, pattern.r#type()) {
                     element
@@ -1393,6 +1389,7 @@ impl<'a> Visitor<'a> for TypeInferencer<'a> {
                 "[inference] variable_declaration: {}, {}",
                 var_pattern, init
             );
+
             var_pattern
                 .r#type()
                 .unify(self.arena, init.r#type())

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -1369,15 +1369,13 @@ impl<'a> Visitor<'a> for TypeInferencer<'a> {
                         .errors()
                         .push_semantic_error(SemanticError::TypeError(err));
                 }
-            } else {
-                if let Err(err) = element
-                    .r#type()
-                    .unify(self.arena, array_type.element_type())
-                {
-                    element
-                        .errors()
-                        .push_semantic_error(SemanticError::TypeError(err));
-                }
+            } else if let Err(err) = element
+                .r#type()
+                .unify(self.arena, array_type.element_type())
+            {
+                element
+                    .errors()
+                    .push_semantic_error(SemanticError::TypeError(err));
             }
         }
     }

--- a/src/syntax/code.rs
+++ b/src/syntax/code.rs
@@ -19,6 +19,10 @@ impl<'a> Code<'a> {
     pub fn len(&self) -> usize {
         self.code.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.code.is_empty()
+    }
 }
 
 #[derive(Debug)]

--- a/src/syntax/code.rs
+++ b/src/syntax/code.rs
@@ -15,6 +15,10 @@ impl<'a> Code<'a> {
     pub fn iter(&self) -> CodeKindIter<'_, 'a> {
         CodeKindIter::from(self.code.iter())
     }
+
+    pub fn len(&self) -> usize {
+        self.code.len()
+    }
 }
 
 #[derive(Debug)]

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -1158,7 +1158,12 @@ impl<'a, 't> Parser<'a, 't> {
             }
         }
 
-        arena.alloc(Block::new(arena, body, code.build(arena)))
+        arena.alloc(Block::new(
+            arena,
+            body,
+            code.build(arena),
+            Some(self.tokenizer.current_insertion_range()),
+        ))
     }
 
     fn _parse_optional_item<T>(

--- a/src/syntax/traverse.rs
+++ b/src/syntax/traverse.rs
@@ -586,6 +586,8 @@ fn dispatch_enter<'a>(visitor: &mut dyn Visitor<'a>, path: &'a NodePath<'a>) {
         NodeKind::ValueFieldPattern(kind) => {
             visitor.enter_value_field_pattern(path, kind);
 
+            // Since omitted value pattern doesn't appear in AST,
+            // we have to visit pseudo value node manually.
             if let Some(value_pattern) = kind.omitted_value() {
                 visitor.enter_pattern(path, value_pattern);
 

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -512,6 +512,14 @@ impl<'a> AstErrors<'a> {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.semantic_errors.borrow().is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.semantic_errors.borrow().len()
+    }
+
     pub fn push_semantic_error(&self, error: SemanticError<'a>) {
         self.semantic_errors.borrow_mut().push(error);
     }

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -1212,7 +1212,7 @@ impl<'a> Block<'a> {
 
 impl<'a> Node<'a> for Block<'a> {
     fn range_hint(&self) -> Option<EffectiveRange> {
-        if self.code.len() == 0 {
+        if self.code.is_empty() {
             self.range_hint
         } else {
             None

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -122,6 +122,12 @@ pub enum NodeKind<'a> {
     GroupedExpression(&'a GroupedExpression<'a>),
 }
 
+impl<'a> From<&'a Expression<'a>> for NodeKind<'a> {
+    fn from(expr: &'a Expression<'a>) -> Self {
+        NodeKind::Expression(expr)
+    }
+}
+
 impl<'a> From<&ExpressionKind<'a>> for NodeKind<'a> {
     fn from(expr: &ExpressionKind<'a>) -> Self {
         match expr {

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -81,6 +81,10 @@ pub trait Node<'arena>: fmt::Display {
     fn errors(&self) -> &AstErrors<'arena>;
 }
 
+pub trait TypedNode<'arena>: Node<'arena> {
+    fn r#type(&self) -> TypeKind<'arena>;
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum NodeKind<'a> {
     Program(&'a Program<'a>),
@@ -719,10 +723,6 @@ impl<'a> StructDefinition<'a> {
     }
 
     // for semantic analysis
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -747,6 +747,12 @@ impl<'a> Node<'a> for StructDefinition<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for StructDefinition<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -854,10 +860,6 @@ impl<'a> TypeAnnotation<'a> {
     }
 
     // for semantic analysis
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -874,6 +876,12 @@ impl<'a> Node<'a> for TypeAnnotation<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for TypeAnnotation<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -939,10 +947,6 @@ impl<'a> FunctionDefinition<'a> {
     }
 
     // for semantic analysis
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -967,6 +971,12 @@ impl<'a> Node<'a> for FunctionDefinition<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for FunctionDefinition<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -1018,10 +1028,6 @@ impl<'a> FunctionParameter<'a> {
     }
 
     // for semantic analysis
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -1046,6 +1052,12 @@ impl<'a> Node<'a> for FunctionParameter<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for FunctionParameter<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -1204,10 +1216,6 @@ impl<'a> Block<'a> {
         stmt.expression()
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -1232,6 +1240,12 @@ impl<'a> Node<'a> for Block<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for Block<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -1364,24 +1378,6 @@ impl<'a> Expression<'a> {
     pub fn is_variable_expression(&self) -> bool {
         matches!(self.kind, ExpressionKind::VariableExpression(..))
     }
-
-    pub fn r#type(&self) -> TypeKind<'a> {
-        match self.kind() {
-            ExpressionKind::IntegerLiteral(expr) => expr.r#type(),
-            ExpressionKind::StringLiteral(expr) => expr.r#type(),
-            ExpressionKind::VariableExpression(expr) => expr.r#type(),
-            ExpressionKind::BinaryExpression(expr) => expr.r#type(),
-            ExpressionKind::UnaryExpression(expr) => expr.r#type(),
-            ExpressionKind::SubscriptExpression(expr) => expr.r#type(),
-            ExpressionKind::CallExpression(expr) => expr.r#type(),
-            ExpressionKind::ArrayExpression(expr) => expr.r#type(),
-            ExpressionKind::IfExpression(expr) => expr.r#type(),
-            ExpressionKind::CaseExpression(expr) => expr.r#type(),
-            ExpressionKind::MemberExpression(expr) => expr.r#type(),
-            ExpressionKind::StructLiteral(expr) => expr.r#type(),
-            ExpressionKind::GroupedExpression(expr) => expr.r#type(),
-        }
-    }
 }
 
 impl<'a> Node<'a> for Expression<'a> {
@@ -1404,6 +1400,26 @@ impl<'a> Node<'a> for Expression<'a> {
             ExpressionKind::MemberExpression(expr) => expr.errors(),
             ExpressionKind::StructLiteral(expr) => expr.errors(),
             ExpressionKind::GroupedExpression(expr) => expr.errors(),
+        }
+    }
+}
+
+impl<'a> TypedNode<'a> for Expression<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        match self.kind() {
+            ExpressionKind::IntegerLiteral(expr) => expr.r#type(),
+            ExpressionKind::StringLiteral(expr) => expr.r#type(),
+            ExpressionKind::VariableExpression(expr) => expr.r#type(),
+            ExpressionKind::BinaryExpression(expr) => expr.r#type(),
+            ExpressionKind::UnaryExpression(expr) => expr.r#type(),
+            ExpressionKind::SubscriptExpression(expr) => expr.r#type(),
+            ExpressionKind::CallExpression(expr) => expr.r#type(),
+            ExpressionKind::ArrayExpression(expr) => expr.r#type(),
+            ExpressionKind::IfExpression(expr) => expr.r#type(),
+            ExpressionKind::CaseExpression(expr) => expr.r#type(),
+            ExpressionKind::MemberExpression(expr) => expr.r#type(),
+            ExpressionKind::StructLiteral(expr) => expr.r#type(),
+            ExpressionKind::GroupedExpression(expr) => expr.r#type(),
         }
     }
 }
@@ -1451,10 +1467,6 @@ impl<'a> StructLiteral<'a> {
         self.r#type().struct_type()
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -1471,6 +1483,12 @@ impl<'a> Node<'a> for StructLiteral<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for StructLiteral<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -1513,10 +1531,6 @@ impl<'a> ValueField<'a> {
         self.value
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -1533,6 +1547,12 @@ impl<'a> Node<'a> for ValueField<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for ValueField<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -1582,10 +1602,6 @@ impl<'a> BinaryExpression<'a> {
         self.rhs
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -1602,6 +1618,12 @@ impl<'a> Node<'a> for BinaryExpression<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for BinaryExpression<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -1644,10 +1666,6 @@ impl<'a> UnaryExpression<'a> {
         self.operand
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -1664,6 +1682,12 @@ impl<'a> Node<'a> for UnaryExpression<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for UnaryExpression<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -1754,10 +1778,6 @@ impl<'a> SubscriptExpression<'a> {
         self.arguments.iter().copied()
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -1774,6 +1794,12 @@ impl<'a> Node<'a> for SubscriptExpression<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for SubscriptExpression<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -1821,10 +1847,6 @@ impl<'a> CallExpression<'a> {
         function_type.function_type()
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -1841,6 +1863,12 @@ impl<'a> Node<'a> for CallExpression<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for CallExpression<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -1883,10 +1911,6 @@ impl<'a> MemberExpression<'a> {
         self.field
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -1903,6 +1927,12 @@ impl<'a> Node<'a> for MemberExpression<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for MemberExpression<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -1942,10 +1972,6 @@ impl<'a> ArrayExpression<'a> {
         self.elements.iter().copied()
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -1962,6 +1988,12 @@ impl<'a> Node<'a> for ArrayExpression<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for ArrayExpression<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -2011,10 +2043,6 @@ impl<'a> IfExpression<'a> {
         self.else_body
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -2031,6 +2059,12 @@ impl<'a> Node<'a> for IfExpression<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for IfExpression<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -2080,10 +2114,6 @@ impl<'a> CaseExpression<'a> {
         self.else_body
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -2104,6 +2134,12 @@ impl<'a> Node<'a> for CaseExpression<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for CaseExpression<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -2160,10 +2196,6 @@ impl<'a> CaseArm<'a> {
     pub fn then_body(&self) -> &'a Block<'a> {
         self.then_body
     }
-
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.then_body.r#type()
-    }
 }
 
 impl<'a> Node<'a> for CaseArm<'a> {
@@ -2173,6 +2205,12 @@ impl<'a> Node<'a> for CaseArm<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for CaseArm<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.then_body.r#type()
     }
 }
 
@@ -2202,10 +2240,6 @@ impl<'a> IntegerLiteral<'a> {
     pub fn value(&self) -> i32 {
         self.value
     }
-
-    pub fn r#type(&self) -> TypeKind<'a> {
-        TypeKind::Int32
-    }
 }
 
 impl<'a> Node<'a> for IntegerLiteral<'a> {
@@ -2215,6 +2249,12 @@ impl<'a> Node<'a> for IntegerLiteral<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for IntegerLiteral<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        TypeKind::Int32
     }
 }
 
@@ -2243,10 +2283,6 @@ impl<'a> StringLiteral<'a> {
     pub fn value(&self) -> Option<&str> {
         self.value.as_deref()
     }
-
-    pub fn r#type(&self) -> TypeKind<'a> {
-        TypeKind::String
-    }
 }
 
 impl<'a> Node<'a> for StringLiteral<'a> {
@@ -2256,6 +2292,12 @@ impl<'a> Node<'a> for StringLiteral<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for StringLiteral<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        TypeKind::String
     }
 }
 
@@ -2296,10 +2338,6 @@ impl<'a> VariableExpression<'a> {
         self.id.as_str()
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -2316,6 +2354,12 @@ impl<'a> Node<'a> for VariableExpression<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for VariableExpression<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -2352,10 +2396,6 @@ impl<'a> GroupedExpression<'a> {
     }
 
     // for semantic analysis
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -2376,6 +2416,12 @@ impl<'a> Node<'a> for GroupedExpression<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for GroupedExpression<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -2421,18 +2467,6 @@ impl<'a> Pattern<'a> {
     pub fn kind(&self) -> &PatternKind<'a> {
         &self.kind
     }
-
-    pub fn r#type(&self) -> TypeKind<'a> {
-        match self.kind() {
-            PatternKind::IntegerPattern(pattern) => pattern.r#type(),
-            PatternKind::StringPattern(pattern) => pattern.r#type(),
-            PatternKind::VariablePattern(pattern) => pattern.r#type(),
-            PatternKind::ArrayPattern(pattern) => pattern.r#type(),
-            PatternKind::RestPattern(pattern) => pattern.r#type(),
-            PatternKind::StructPattern(pattern) => pattern.r#type(),
-            PatternKind::ValueFieldPattern(pattern) => pattern.r#type(),
-        }
-    }
 }
 
 impl<'a> Node<'a> for Pattern<'a> {
@@ -2449,6 +2483,20 @@ impl<'a> Node<'a> for Pattern<'a> {
             PatternKind::RestPattern(pattern) => pattern.errors(),
             PatternKind::StructPattern(pattern) => pattern.errors(),
             PatternKind::ValueFieldPattern(pattern) => pattern.errors(),
+        }
+    }
+}
+
+impl<'a> TypedNode<'a> for Pattern<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        match self.kind() {
+            PatternKind::IntegerPattern(pattern) => pattern.r#type(),
+            PatternKind::StringPattern(pattern) => pattern.r#type(),
+            PatternKind::VariablePattern(pattern) => pattern.r#type(),
+            PatternKind::ArrayPattern(pattern) => pattern.r#type(),
+            PatternKind::RestPattern(pattern) => pattern.r#type(),
+            PatternKind::StructPattern(pattern) => pattern.r#type(),
+            PatternKind::ValueFieldPattern(pattern) => pattern.r#type(),
         }
     }
 }
@@ -2491,10 +2539,6 @@ impl<'a> VariablePattern<'a> {
     }
 
     // for semantic analysis
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -2519,6 +2563,12 @@ impl<'a> Node<'a> for VariablePattern<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for VariablePattern<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -2554,10 +2604,6 @@ impl<'a> ArrayPattern<'a> {
         self.elements.iter().copied()
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -2574,6 +2620,12 @@ impl<'a> Node<'a> for ArrayPattern<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for ArrayPattern<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -2609,10 +2661,6 @@ impl<'a> RestPattern<'a> {
         self.variable_pattern
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -2629,6 +2677,12 @@ impl<'a> Node<'a> for RestPattern<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for RestPattern<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -2671,10 +2725,6 @@ impl<'a> StructPattern<'a> {
         self.fields.iter().copied()
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -2691,6 +2741,12 @@ impl<'a> Node<'a> for StructPattern<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for StructPattern<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 
@@ -2754,10 +2810,6 @@ impl<'a> ValueFieldPattern<'a> {
         self.omitted_value
     }
 
-    pub fn r#type(&self) -> TypeKind<'a> {
-        self.get_type().expect("Uninitialized semantic value.")
-    }
-
     pub fn get_type(&self) -> Option<TypeKind<'a>> {
         self.r#type.get()
     }
@@ -2774,6 +2826,12 @@ impl<'a> Node<'a> for ValueFieldPattern<'a> {
 
     fn errors(&self) -> &AstErrors<'a> {
         &self.errors
+    }
+}
+
+impl<'a> TypedNode<'a> for ValueFieldPattern<'a> {
+    fn r#type(&self) -> TypeKind<'a> {
+        self.get_type().expect("Uninitialized semantic value.")
     }
 }
 

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -304,6 +304,13 @@ impl<'a> NodeKind<'a> {
         None
     }
 
+    pub fn case_expression(&self) -> Option<&'a CaseExpression<'a>> {
+        if let NodeKind::CaseExpression(node) = self {
+            return Some(node);
+        }
+        None
+    }
+
     pub fn member_expression(&self) -> Option<&'a MemberExpression<'a>> {
         if let NodeKind::MemberExpression(node) = self {
             return Some(node);

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -49,15 +49,16 @@ use crate::util::collections::RefVecIter;
 use std::cell::{Cell, RefCell};
 use std::fmt;
 
-pub trait Node<'arena> {
+pub trait Node<'arena>: fmt::Display {
     fn code(&self) -> CodeKindIter<'_, 'arena>;
 
     /// Returns the effective range of this node.
     fn range(&self) -> EffectiveRange {
         let mut it = self.code();
 
-        // node must be at least one token.
-        let init = it.next().unwrap();
+        let next = it.next();
+        let init = next.unwrap_or_else(|| panic!("node must have at least one token: {}", self));
+
         it.fold(init.range(), |acc, kind| kind.range().union(&acc))
     }
 
@@ -2083,6 +2084,10 @@ impl<'a> CaseArm<'a> {
 
     pub fn then_body(&self) -> &'a Block<'a> {
         self.then_body
+    }
+
+    pub fn r#type(&self) -> TypeKind<'a> {
+        self.then_body.r#type()
     }
 }
 

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -2473,6 +2473,14 @@ impl<'a> Pattern<'a> {
     pub fn kind(&self) -> &PatternKind<'a> {
         &self.kind
     }
+
+    pub fn rest_pattern(&self) -> Option<&RestPattern<'a>> {
+        if let PatternKind::RestPattern(pattern) = self.kind() {
+            Some(pattern)
+        } else {
+            None
+        }
+    }
 }
 
 impl<'a> Node<'a> for Pattern<'a> {


### PR DESCRIPTION
## Todo

- [x] case expression type
- [x] handling empty block (it doesn't have any syntactic token)

#### type inference for pattern matching in case expression

- [x] each pattern type must be same as the type of head expression
- [x] Infer type of member expression
- [x] Deny types which contains unresolved type parameters
- [x] infer type of array literal
- [x] infer type of pattern of array element
- [x] Infer rest pattern of array pattern
- [x] Infer type of each fields of struct pattern